### PR TITLE
Fix scrutiny binary location

### DIFF
--- a/docker/Dockerfile.web
+++ b/docker/Dockerfile.web
@@ -34,4 +34,4 @@ COPY --from=frontendbuild /scrutiny/dist /scrutiny/web
 RUN chmod +x /scrutiny/bin/scrutiny && \
     mkdir -p /scrutiny/web && \
     mkdir -p /scrutiny/config
-CMD ["/scrutiny", "start"]
+CMD ["/scrutiny/bin/scrutiny", "start"]


### PR DESCRIPTION
> ERROR: for web  Cannot start service web: OCI runtime create failed: container_linux.go:349: starting container process caused "exec: \"/scrutiny\": permission denied": unknown

This happens because it is a directory, the binary itself is in a different place