### PR TITLE
retrieve all device data. SAS devices do not return power on hours wh…

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ analogj/scrutiny
 
 - `/run/udev` is necessary to provide the Scrutiny collector with access to your device metadata
 - `--cap-add SYS_RAWIO` is necessary to allow `smartctl` permission to query your device SMART data
-    - NOTE: If you have NVMe drives, you must use `--cap-add SYS_ADMIN` instead. See [#26](https://github.com/AnalogJ/scrutiny/issues/26)
+    - NOTE: If you have NVMe drives, you must use `--cap-add SYS_ADMIN` instead. See issue [#26](https://github.com/AnalogJ/scrutiny/issues/26#issuecomment-696817130)
 - `--device` entries are required to ensure that your hard disk devices are accessible within the container
 - `analogj/scrutiny` is a omnibus image, containing both the webapp server (frontend & api) as well as the S.M.A.R.T metric collector. (see below)
 

--- a/collector/pkg/collector/metrics.go
+++ b/collector/pkg/collector/metrics.go
@@ -105,7 +105,7 @@ func (mc *MetricsCollector) Collect(deviceWWN string, deviceName string, deviceT
 	//defer wg.Done()
 	mc.logger.Infof("Collecting smartctl results for %s\n", deviceName)
 
-	args := []string{"-a", "-j"}
+	args := []string{"-x", "-j"}
 	//only include the device type if its a non-standard one. In some cases ata drives are detected as scsi in docker, and metadata is lost.
 	if len(deviceType) > 0 && deviceType != "scsi" && deviceType != "ata" {
 		args = append(args, "-d", deviceType)


### PR DESCRIPTION
…en using `-a` flag (unlike other device types).

fixes #43
fixes #9