### PR TITLE
Use StringFlag for COLLECTOR_HOST_ID

### DIFF
--- a/collector/cmd/collector-metrics/collector-metrics.go
+++ b/collector/cmd/collector-metrics/collector-metrics.go
@@ -161,9 +161,10 @@ OPTIONS:
 						EnvVars: []string{"COLLECTOR_DEBUG", "DEBUG"},
 					},
 
-					&cli.BoolFlag{
+					&cli.StringFlag{
 						Name:    "host-id",
 						Usage:   "Host identifier/label, used for grouping devices",
+						Value:   "",
 						EnvVars: []string{"COLLECTOR_HOST_ID"},
 					},
 				},


### PR DESCRIPTION
I have zero idea about Go, but testing the Host ID feature, I realised I couldn't use the  `COLLECTOR_HOST_ID` environment variable, and looks like it's because of this, but please double check!