### PR TITLE
Fix manual call to scrutiny-collector-metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ For users of the docker Hub/Spoke deployment or manual install: initially the da
 After the first collector run, you'll be greeted with a list of all your hard drives and their current smart status.
 
 ```
-docker exec scrutiny /scrutiny/bin/scrutiny-collector-metrics run
+docker exec scrutiny /usr/local/bin/scrutiny-collector-metrics run
 ```
 
 # Configuration


### PR DESCRIPTION
Current `docker exec scrutiny /scrutiny/bin/scrutiny-collector-metrics run` command gives the following error because of an incorrect path to the `scrutiny-collector-metrics` program

OCI runtime exec failed: exec failed: container_linux.go:380: starting container process caused: exec: "/scrutiny/bin/scrutiny-collector-metrics": stat /scrutiny/bin/scrutiny-collector-metrics: no such file or directory: unknown