### PR TITLE
Add Ansible instructions

### DIFF
--- a/docs/INSTALL_ANSIBLE.md
+++ b/docs/INSTALL_ANSIBLE.md
@@ -1,0 +1,17 @@
+# Ansible Install
+
+[Zorlin](https://github.com/Zorlin) has developed and now maintains [an Ansible playbook](https://github.com/Zorlin/scrutiny-playbook) which automates the steps involved in manually setting up Scrutiny.
+
+Using it is simple:
+
+* Grab a copy of the playbook
+* Follow the directions in the playbook repository
+* Run `ansible-playbook site.yml`
+* Visit http://your-machine:8080 to see your new Scrutiny installation.
+
+It will automatically pull metrics from machines once a day, at 1am.
+
+You can see it in action below.
+
+[![asciicast](https://asciinema.org/a/493531.svg)](https://asciinema.org/a/493531)
+

--- a/docs/INSTALL_MANUAL.md
+++ b/docs/INSTALL_MANUAL.md
@@ -2,7 +2,7 @@
 
 While the easiest way to get started with [Scrutiny is using Docker](https://github.com/AnalogJ/scrutiny#docker),
 it is possible to run it manually without much work. You can even mix and match, using Docker for one component and
-a manual installation for the other.
+a manual installation for the other. There's also [an installer](INSTALL_ANSIBLE.md) which automates this manual installation procedure.
 
 Scrutiny is made up of two components: a collector and a webapp/api. Here's how each component can be deployed manually.
 


### PR DESCRIPTION
This adds instructions on how to use the Ansible playbook for Scrutiny to automatically install it, including InfluxDB2.

(A future version of the Ansible playbook will also offer the option to choose between "manual" and "Docker" install styles for each host)