### PR TITLE
Typo in INSTALL_SYNOLOGY_COLLECTOR.md

### DIFF
--- a/docs/INSTALL_SYNOLOGY_COLLECTOR.md
+++ b/docs/INSTALL_SYNOLOGY_COLLECTOR.md
@@ -91,7 +91,7 @@ wget https://raw.githubusercontent.com/smartmontools/smartmontools/master/smartm
 ```
 #!/bin/bash
 
-/volume1/\@Entware/scrutiny/bin/scrutiny-collector-metrics-linux-arm64 run --config /volume1/\@Entware/scrutiny/config/collector.yaml
+/volume1/\@Entware/scrutiny/bin/scrutiny-collector-metrics-linux-arm64 run --config /volume1/\@Entware/scrutiny/conf/collector.yaml
 ```
 
 ## Set up Synology to run a scheduled task. 


### PR DESCRIPTION
Typo: Created and loaded config into `conf/`, but `config/` is specified in the `--config` argument