### PR TITLE
[docs] Make `run_collect.sh` executable in `docs/INSTALL_SYNOLOGY_COLLECTOR.md`

### DIFF
--- a/docs/INSTALL_SYNOLOGY_COLLECTOR.md
+++ b/docs/INSTALL_SYNOLOGY_COLLECTOR.md
@@ -94,6 +94,10 @@ wget https://raw.githubusercontent.com/smartmontools/smartmontools/master/smartm
 /volume1/\@Entware/scrutiny/bin/scrutiny-collector-metrics-linux-arm64 run --config /volume1/\@Entware/scrutiny/config/collector.yaml
 ```
 
+**Make `run_collect.sh` executable**
+
+`chmod +x /volume1/\@Entware/scrutiny/bin/run_collect.sh`
+
 ## Set up Synology to run a scheduled task. 
 
 Log in to DSM and do the following:


### PR DESCRIPTION
Synology task will fail when not executable:

```
/bin/bash: /volume1/@Entware/scrutiny/bin/run_collect.sh: Permission denied
```