### PR TITLE
Add missing setup command for udev troubleshooting

### DIFF
--- a/docs/TROUBLESHOOTING_UDEV.md
+++ b/docs/TROUBLESHOOTING_UDEV.md
@@ -6,6 +6,7 @@ To install `eudev` in Alpine Linux (run as root):
 
 ```
 apk add eudev
+setup-udev
 ```
 
 Once your `udev` implementation is installed, create `/run/udev` with the following command:


### PR DESCRIPTION
I just learned about a command that's required after installing eudev on Alpine Linux to ensure udev updates are triggered on boot. I've added this to the TROUBLESHOOTING_UDEV doc.