### PR TITLE
Increase collector timeout

### DIFF
--- a/collector/pkg/collector/base.go
+++ b/collector/pkg/collector/base.go
@@ -8,7 +8,7 @@ import (
 	"time"
 )
 
-var httpClient = &http.Client{Timeout: 10 * time.Second}
+var httpClient = &http.Client{Timeout: 60 * time.Second}
 
 type BaseCollector struct {
 	logger *logrus.Entry


### PR DESCRIPTION
This pr increases http requests timeout.
Will fix old issues like #318 #185 #183

The problem happens when smartctl returns lot of data for one HDD and the http post request will not end in 10 seconds.
The error is: `Client.Timeout exceeded while awaiting headers`
I increased the timeout to 60 seconds and tested eveything. It solves the issue completely.
