### PR TITLE
Improve process handling

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -74,4 +74,4 @@ RUN chmod 0644 /etc/cron.d/scrutiny && \
     chmod +x /etc/services.d/*/run && \
     chmod +x /etc/services.d/*/finish
 
-CMD ["/init"]
+ENTRYPOINT ["/init"]

--- a/rootfs/etc/services.d/cron/run
+++ b/rootfs/etc/services.d/cron/run
@@ -1,4 +1,4 @@
 #!/command/with-contenv bash
 
 echo "starting cron"
-cron -f -L 15
+exec cron -f -L 15

--- a/rootfs/etc/services.d/influxdb/run
+++ b/rootfs/etc/services.d/influxdb/run
@@ -14,4 +14,4 @@ EOF
 fi
 
 echo "starting influxdb"
-influxd run
+exec influxd run

--- a/rootfs/etc/services.d/scrutiny/run
+++ b/rootfs/etc/services.d/scrutiny/run
@@ -4,4 +4,4 @@ echo "waiting for influxdb"
 until $(curl --output /dev/null --silent --head --fail http://localhost:8086/health); do echo "influxdb not ready" && sleep 5; done
 
 echo "starting scrutiny"
-scrutiny start
+exec scrutiny start


### PR DESCRIPTION
The scrutiny container currently spawns multiple superfluous bash processes.

` docker top scrutiny acxf` yields:

```
PID                 TTY                 STAT                TIME                COMMAND
3265068             ?                   Ss                  0:00                \_ s6-svscan
3265188             ?                   S                   0:00                | \_ s6-supervise
3265397             ?                   S                   0:00                | \_ s6-supervise
3265402             ?                   Ss                  0:00                | | \_ bash
3265412             ?                   S                   0:00                | | \_ cron
3265398             ?                   S                   0:00                | \_ s6-supervise
3265406             ?                   Ss                  0:00                | | \_ bash
3265427             ?                   Sl                  1:10                | | \_ influxd
3265399             ?                   S                   0:00                | \_ s6-supervise
3265400             ?                   S                   0:00                | \_ s6-supervise
3265403             ?                   Ss                  0:00                | \_ bash
3265575             ?                   Sl                  0:03                | \_ scrutiny
3265821             pts/0               Ss+                 0:00                \_ sh
```

This PR switches the shell scripts to run their main process with `exec` effectively replacing the shells process.