### PR TITLE
Delete temporary deb file from omnibus Docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,7 +30,8 @@ RUN apt-get update && apt-get install -y cron smartmontools ca-certificates curl
     && tar xzf /tmp/s6-overlay-${S6_ARCH}.tar.gz -C / \
     && rm -rf /tmp/s6-overlay-${S6_ARCH}.tar.gz \
     && curl -L https://dl.influxdata.com/influxdb/releases/influxdb2-2.2.0-${TARGETARCH}.deb --output /tmp/influxdb2-2.2.0-${TARGETARCH}.deb \
-    && dpkg -i --force-all /tmp/influxdb2-2.2.0-${TARGETARCH}.deb
+    && dpkg -i --force-all /tmp/influxdb2-2.2.0-${TARGETARCH}.deb \
+    && rm -rf /tmp/influxdb2-2.2.0-${TARGETARCH}.deb
 
 COPY /rootfs /
 


### PR DESCRIPTION
This considerably reduces the Docker image size for the `omnibus` variant:

```
scrutiny-omnibus-master         latest            cd7a7dde100b   9 minutes ago   538MB
scrutiny-omnibus-fix-applied    latest            5f7ac124ef50   6 minutes ago   431MB
```