### PR TITLE
Allow configuration files with yml extension

### DIFF
--- a/collector/cmd/collector-metrics/collector-metrics.go
+++ b/collector/cmd/collector-metrics/collector-metrics.go
@@ -30,8 +30,14 @@ func main() {
 		os.Exit(1)
 	}
 
+	configFilePath := "/opt/scrutiny/config/collector.yaml"
+	configFilePathAlternative := "/opt/scrutiny/config/collector.yml"
+	if !utils.FileExists(configFilePath) && utils.FileExists(configFilePathAlternative) {
+		configFilePath = configFilePathAlternative
+	}
+
 	//we're going to load the config file manually, since we need to validate it.
-	err = config.ReadConfig("/opt/scrutiny/config/collector.yaml") // Find and read the config file
+	err = config.ReadConfig(configFilePath) // Find and read the config file
 	if _, ok := err.(errors.ConfigFileMissingError); ok {          // Handle errors reading the config file
 		//ignore "could not find config file"
 	} else if err != nil {

--- a/webapp/backend/cmd/scrutiny/scrutiny.go
+++ b/webapp/backend/cmd/scrutiny/scrutiny.go
@@ -29,8 +29,14 @@ func main() {
 		os.Exit(1)
 	}
 
+	configFilePath := "/opt/scrutiny/config/scrutiny.yaml"
+	configFilePathAlternative := "/opt/scrutiny/config/scrutiny.yml"
+	if !utils.FileExists(configFilePath) && utils.FileExists(configFilePathAlternative) {
+		configFilePath = configFilePathAlternative
+	}
+
 	//we're going to load the config file manually, since we need to validate it.
-	err = config.ReadConfig("/opt/scrutiny/config/scrutiny.yaml") // Find and read the config file
+	err = config.ReadConfig(configFilePath) // Find and read the config file
 	if _, ok := err.(errors.ConfigFileMissingError); ok {         // Handle errors reading the config file
 		//ignore "could not find config file"
 	} else if err != nil {


### PR DESCRIPTION
If a `collector.yml` or `scrutiny.yml` configuration file is present, use it as long as a `.yaml` version is not available too.

Fixes #79