### PR TITLE
Update 188 attribute to cover 0 value

### DIFF
--- a/webapp/backend/pkg/thresholds/ata_attribute_metadata.go
+++ b/webapp/backend/pkg/thresholds/ata_attribute_metadata.go
@@ -693,6 +693,12 @@ var AtaMetadata = map[int]AtaAttributeMetadata{
 		},
 		ObservedThresholds: []ObservedThreshold{
 			{
+				Low:               0,
+				High:              0,
+				AnnualFailureRate: 0.024893587674442153,
+				ErrorInterval:     []float64{0.020857343769186413, 0.0294830350167543},
+			},
+			{
 				Low: 0,
 				// This is set arbitrarily to avoid notifications caused by low
 				// historical numbers of command timeouts (e.g. caused by a bad cable)


### PR DESCRIPTION
Hello

I noticed that in case 188 attribute has value `0` it is shown as `warn` with the `Could not determine Observed Failure Rate for Critical Attribute` tooltip.

This is happening because [comparison logic in smart_ata_attribute.go](https://github.com/AnalogJ/scrutiny/blob/5bbd4c3b64f24139350e6d9c27548151a046d116/webapp/backend/pkg/models/measurements/smart_ata_attribute.go#L135-L137) doesn't include `low` value. But in case `low == high` bucket will be selected.