### PR TITLE
rebase docker image to debian 12 (bookworm)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,7 +18,8 @@ WORKDIR /go/src/github.com/analogj/scrutiny
 COPY --link . /go/src/github.com/analogj/scrutiny
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive \
     apt-get install -y --no-install-recommends \
-    file
+    file \
+    && rm -rf /var/lib/apt/lists/*
 RUN make binary-clean binary-all WEB_BINARY_NAME=scrutiny
 
 
@@ -40,15 +41,16 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive \
     curl \
     smartmontools \
     tzdata \
-    && update-ca-certificates
-RUN case ${TARGETARCH} in \
-        "amd64")  S6_ARCH=amd64  ;; \
-        "arm64")  S6_ARCH=aarch64  ;; \
-    esac \
+    && rm -rf /var/lib/apt/lists/* \
+    && update-ca-certificates \
+    && case ${TARGETARCH} in \
+           "amd64")  S6_ARCH=amd64  ;; \
+           "arm64")  S6_ARCH=aarch64  ;; \
+       esac \
     && curl https://github.com/just-containers/s6-overlay/releases/download/v${S6VER}/s6-overlay-${S6_ARCH}.tar.gz -L -s --output /tmp/s6-overlay-${S6_ARCH}.tar.gz \
     && tar xzf /tmp/s6-overlay-${S6_ARCH}.tar.gz -C / \
-    && rm -rf /tmp/s6-overlay-${S6_ARCH}.tar.gz
-RUN curl -L https://dl.influxdata.com/influxdb/releases/influxdb2-${INFLUXVER}-${TARGETARCH}.deb --output /tmp/influxdb2-${INFLUXVER}-${TARGETARCH}.deb \
+    && rm -rf /tmp/s6-overlay-${S6_ARCH}.tar.gz \
+    curl -L https://dl.influxdata.com/influxdb/releases/influxdb2-${INFLUXVER}-${TARGETARCH}.deb --output /tmp/influxdb2-${INFLUXVER}-${TARGETARCH}.deb \
     && ln -s /usr/bin/false /bin/false \
     && ln -s /usr/bin/bash /bin/bash \
     && dpkg -i --force-all /tmp/influxdb2-${INFLUXVER}-${TARGETARCH}.deb \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -50,7 +50,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive \
     && curl https://github.com/just-containers/s6-overlay/releases/download/v${S6VER}/s6-overlay-${S6_ARCH}.tar.gz -L -s --output /tmp/s6-overlay-${S6_ARCH}.tar.gz \
     && tar xzf /tmp/s6-overlay-${S6_ARCH}.tar.gz -C / \
     && rm -rf /tmp/s6-overlay-${S6_ARCH}.tar.gz \
-    curl -L https://dl.influxdata.com/influxdb/releases/influxdb2-${INFLUXVER}-${TARGETARCH}.deb --output /tmp/influxdb2-${INFLUXVER}-${TARGETARCH}.deb \
+    && curl -L https://dl.influxdata.com/influxdb/releases/influxdb2-${INFLUXVER}-${TARGETARCH}.deb --output /tmp/influxdb2-${INFLUXVER}-${TARGETARCH}.deb \
     && ln -s /usr/bin/false /bin/false \
     && ln -s /usr/bin/bash /bin/bash \
     && dpkg -i --force-all /tmp/influxdb2-${INFLUXVER}-${TARGETARCH}.deb \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,15 +12,18 @@ RUN make binary-frontend
 
 
 ######## Build the backend
-FROM golang:1.20-bullseye as backendbuild
+FROM golang:1.20-bookworm as backendbuild
 
 WORKDIR /go/src/github.com/analogj/scrutiny
 COPY --link . /go/src/github.com/analogj/scrutiny
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive \
+    apt-get install -y --no-install-recommends \
+    file
 RUN make binary-clean binary-all WEB_BINARY_NAME=scrutiny
 
 
 ######## Combine build artifacts in runtime image
-FROM debian:bullseye-slim as runtime
+FROM debian:bookworm-slim as runtime
 ARG TARGETARCH
 EXPOSE 8080
 WORKDIR /opt/scrutiny
@@ -28,6 +31,7 @@ ENV PATH="/opt/scrutiny/bin:${PATH}"
 ENV INFLUXD_CONFIG_PATH=/opt/scrutiny/influxdb
 ENV S6VER="1.21.8.0"
 ENV INFLUXVER="2.2.0"
+SHELL ["/usr/bin/sh", "-c"]
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive \
     apt-get install -y --no-install-recommends \
@@ -36,17 +40,20 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive \
     curl \
     smartmontools \
     tzdata \
-    && update-ca-certificates \
-    &&  case ${TARGETARCH} in \
-            "amd64")  S6_ARCH=amd64  ;; \
-            "arm64")  S6_ARCH=aarch64  ;; \
-        esac \
+    && update-ca-certificates
+RUN case ${TARGETARCH} in \
+        "amd64")  S6_ARCH=amd64  ;; \
+        "arm64")  S6_ARCH=aarch64  ;; \
+    esac \
     && curl https://github.com/just-containers/s6-overlay/releases/download/v${S6VER}/s6-overlay-${S6_ARCH}.tar.gz -L -s --output /tmp/s6-overlay-${S6_ARCH}.tar.gz \
     && tar xzf /tmp/s6-overlay-${S6_ARCH}.tar.gz -C / \
-    && rm -rf /tmp/s6-overlay-${S6_ARCH}.tar.gz \
-    && curl -L https://dl.influxdata.com/influxdb/releases/influxdb2-${INFLUXVER}-${TARGETARCH}.deb --output /tmp/influxdb2-${INFLUXVER}-${TARGETARCH}.deb \
+    && rm -rf /tmp/s6-overlay-${S6_ARCH}.tar.gz
+RUN curl -L https://dl.influxdata.com/influxdb/releases/influxdb2-${INFLUXVER}-${TARGETARCH}.deb --output /tmp/influxdb2-${INFLUXVER}-${TARGETARCH}.deb \
+    && ln -s /usr/bin/false /bin/false \
+    && ln -s /usr/bin/bash /bin/bash \
     && dpkg -i --force-all /tmp/influxdb2-${INFLUXVER}-${TARGETARCH}.deb \
-    && rm -rf /tmp/influxdb2-2.2.0-${TARGETARCH}.deb
+    && rm -f /bin/bash \
+    && rm -rf /tmp/influxdb2-${INFLUXVER}-${TARGETARCH}.deb
 
 COPY /rootfs /
 

--- a/docker/Dockerfile.collector
+++ b/docker/Dockerfile.collector
@@ -10,7 +10,7 @@ WORKDIR /go/src/github.com/analogj/scrutiny
 
 COPY . /go/src/github.com/analogj/scrutiny
 
-RUN apt-get update && apt-get install -y file
+RUN apt-get update && apt-get install -y file && rm -rf /var/lib/apt/lists/*
 RUN make binary-clean binary-collector
 
 ########
@@ -18,7 +18,7 @@ FROM debian:bookworm-slim as runtime
 WORKDIR /opt/scrutiny
 ENV PATH="/opt/scrutiny/bin:${PATH}"
 
-RUN apt-get update && apt-get install -y cron smartmontools ca-certificates tzdata && update-ca-certificates
+RUN apt-get update && apt-get install -y cron smartmontools ca-certificates tzdata && rm -rf /var/lib/apt/lists/* && update-ca-certificates
 
 COPY /docker/entrypoint-collector.sh /entrypoint-collector.sh
 COPY /rootfs/etc/cron.d/scrutiny /etc/cron.d/scrutiny

--- a/docker/Dockerfile.collector
+++ b/docker/Dockerfile.collector
@@ -4,16 +4,17 @@
 
 
 ########
-FROM golang:1.20-bullseye as backendbuild
+FROM golang:1.20-bookworm as backendbuild
 
 WORKDIR /go/src/github.com/analogj/scrutiny
 
 COPY . /go/src/github.com/analogj/scrutiny
 
+RUN apt-get update && apt-get install -y file
 RUN make binary-clean binary-collector
 
 ########
-FROM debian:bullseye-slim as runtime
+FROM debian:bookworm-slim as runtime
 WORKDIR /opt/scrutiny
 ENV PATH="/opt/scrutiny/bin:${PATH}"
 

--- a/docker/Dockerfile.web
+++ b/docker/Dockerfile.web
@@ -11,16 +11,17 @@ COPY --link . /go/src/github.com/analogj/scrutiny
 RUN make binary-frontend
 
 ######## Build the backend
-FROM golang:1.20-bullseye as backendbuild
+FROM golang:1.20-bookworm as backendbuild
 
 WORKDIR /go/src/github.com/analogj/scrutiny
 COPY --link . /go/src/github.com/analogj/scrutiny
 
+RUN apt-get update && apt-get install -y file
 RUN make binary-clean binary-all WEB_BINARY_NAME=scrutiny
 
 
 ######## Combine build artifacts in runtime image
-FROM debian:bullseye-slim as runtime
+FROM debian:bookworm-slim as runtime
 EXPOSE 8080
 WORKDIR /opt/scrutiny
 ENV PATH="/opt/scrutiny/bin:${PATH}"

--- a/docker/Dockerfile.web
+++ b/docker/Dockerfile.web
@@ -16,7 +16,7 @@ FROM golang:1.20-bookworm as backendbuild
 WORKDIR /go/src/github.com/analogj/scrutiny
 COPY --link . /go/src/github.com/analogj/scrutiny
 
-RUN apt-get update && apt-get install -y file
+RUN apt-get update && apt-get install -y file && rm -rf /var/lib/apt/lists/*
 RUN make binary-clean binary-all WEB_BINARY_NAME=scrutiny
 
 
@@ -26,7 +26,7 @@ EXPOSE 8080
 WORKDIR /opt/scrutiny
 ENV PATH="/opt/scrutiny/bin:${PATH}"
 
-RUN apt-get update && apt-get install -y ca-certificates curl tzdata && update-ca-certificates
+RUN apt-get update && apt-get install -y ca-certificates curl tzdata && rm -rf /var/lib/apt/lists/* && update-ca-certificates
 
 COPY --link --from=backendbuild --chmod=755 /go/src/github.com/analogj/scrutiny/scrutiny /opt/scrutiny/bin/
 COPY --link --from=frontendbuild --chmod=644 /go/src/github.com/analogj/scrutiny/dist /opt/scrutiny/web


### PR DESCRIPTION
docker image is now based on debian 12 bookworm so smartmontools is now 7.3.
to resolve [BUG] Could not retrieve device information #538 
https://github.com/AnalogJ/scrutiny/issues/538