### PR TITLE
Use exec on scrutiny-collector cron to ensure signal handling

### DIFF
--- a/docker/entrypoint-collector.sh
+++ b/docker/entrypoint-collector.sh
@@ -25,4 +25,4 @@ fi
 
 # now that we have the env start cron in the foreground
 echo "starting cron"
-su -c "cron -f -L 15" root
+exec su -c "cron -f -L 15" root


### PR DESCRIPTION
Bash ignores the sigterm while the cron child process is running, so when stopping the container, it would stay for 10 seconds until killed. Using exec fixes this and cron / the container now terminates gracefully.