### PR TITLE
fixing cron in #602

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,8 +30,9 @@ EXPOSE 8080
 WORKDIR /opt/scrutiny
 ENV PATH="/opt/scrutiny/bin:${PATH}"
 ENV INFLUXD_CONFIG_PATH=/opt/scrutiny/influxdb
-ENV S6VER="1.21.8.0"
+ENV S6VER="3.1.6.2"
 ENV INFLUXVER="2.2.0"
+ENV S6_SERVICES_READYTIME=1000
 SHELL ["/usr/bin/sh", "-c"]
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive \
@@ -41,20 +42,22 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive \
     curl \
     smartmontools \
     tzdata \
+    procps \
+    xz-utils \
     && rm -rf /var/lib/apt/lists/* \
     && update-ca-certificates \
     && case ${TARGETARCH} in \
            "amd64")  S6_ARCH=amd64  ;; \
            "arm64")  S6_ARCH=aarch64  ;; \
        esac \
-    && curl https://github.com/just-containers/s6-overlay/releases/download/v${S6VER}/s6-overlay-${S6_ARCH}.tar.gz -L -s --output /tmp/s6-overlay-${S6_ARCH}.tar.gz \
-    && tar xzf /tmp/s6-overlay-${S6_ARCH}.tar.gz -C / \
-    && rm -rf /tmp/s6-overlay-${S6_ARCH}.tar.gz \
-    && curl -L https://dl.influxdata.com/influxdb/releases/influxdb2-${INFLUXVER}-${TARGETARCH}.deb --output /tmp/influxdb2-${INFLUXVER}-${TARGETARCH}.deb \
-    && ln -s /usr/bin/false /bin/false \
-    && ln -s /usr/bin/bash /bin/bash \
+    && curl https://github.com/just-containers/s6-overlay/releases/download/v${S6VER}/s6-overlay-noarch.tar.xz -L -s --output /tmp/s6-overlay-noarch.tar.xz \
+    && tar -Jxpf /tmp/s6-overlay-noarch.tar.xz -C / \
+    && rm -rf /tmp/s6-overlay-noarch.tar.xz \
+    && curl https://github.com/just-containers/s6-overlay/releases/download/v${S6VER}/s6-overlay-${S6_ARCH}.tar.xz -L -s --output /tmp/s6-overlay-${S6_ARCH}.tar.xz \
+    && tar -Jxpf /tmp/s6-overlay-${S6_ARCH}.tar.xz -C / \
+    && rm -rf /tmp/s6-overlay-${S6_ARCH}.tar.xz
+RUN curl -L https://dl.influxdata.com/influxdb/releases/influxdb2-${INFLUXVER}-${TARGETARCH}.deb --output /tmp/influxdb2-${INFLUXVER}-${TARGETARCH}.deb \
     && dpkg -i --force-all /tmp/influxdb2-${INFLUXVER}-${TARGETARCH}.deb \
-    && rm -f /bin/bash \
     && rm -rf /tmp/influxdb2-${INFLUXVER}-${TARGETARCH}.deb
 
 COPY /rootfs /
@@ -66,6 +69,9 @@ RUN chmod 0644 /etc/cron.d/scrutiny && \
     rm -f /etc/cron.daily/* && \
     mkdir -p /opt/scrutiny/web && \
     mkdir -p /opt/scrutiny/config && \
-    chmod -R ugo+rwx /opt/scrutiny/config
+    chmod -R ugo+rwx /opt/scrutiny/config && \
+    chmod +x /etc/cont-init.d/* && \
+    chmod +x /etc/services.d/*/run && \
+    chmod +x /etc/services.d/*/finish
 
 CMD ["/init"]

--- a/rootfs/etc/cont-init.d/01-timezone
+++ b/rootfs/etc/cont-init.d/01-timezone
@@ -1,4 +1,4 @@
-#!/usr/bin/with-contenv bash
+#!/command/with-contenv bash
 
 if [ -n "${TZ}" ]
 then

--- a/rootfs/etc/cont-init.d/50-cron-config
+++ b/rootfs/etc/cont-init.d/50-cron-config
@@ -1,4 +1,4 @@
-#!/usr/bin/with-contenv bash
+#!/command/with-contenv bash
 
 # Cron runs in its own isolated environment (usually using only /etc/environment )
 # So when the container starts up, we will do a dump of the runtime environment into a .env file that we

--- a/rootfs/etc/services.d/collector-once/run
+++ b/rootfs/etc/services.d/collector-once/run
@@ -1,13 +1,25 @@
-#!/usr/bin/with-contenv bash
+#!/command/with-contenv bash
+
+# ensure not run (successfully) before
+if [ -f /tmp/custom-init-performed ]; then
+  echo 'INFO: custom init already performed'
+  s6-svc -D /run/service/collector-once     # prevent s6 from restarting service
+  exit 0
+fi
 
 echo "waiting for scrutiny service to start"
-s6-svwait -u /var/run/s6/services/scrutiny
-
-#tell s6 to only run this script once
-s6-svc -O /var/run/s6/services/collector-once
+s6-svwait -u /run/service/scrutiny
 
 # wait until scrutiny is "Ready"
 until $(curl --output /dev/null --silent --head --fail http://localhost:8080/api/health); do echo "scrutiny api not ready" && sleep 5; done
 
 echo "starting scrutiny collector (run-once mode. subsequent calls will be triggered via cron service)"
 /opt/scrutiny/bin/scrutiny-collector-metrics run
+
+# prevent script's core logic from running again
+touch /tmp/custom-init-performed
+
+# prevent s6 from restarting service
+s6-svc -D /run/service/collector-once
+
+exit 0

--- a/rootfs/etc/services.d/cron/finish
+++ b/rootfs/etc/services.d/cron/finish
@@ -1,4 +1,4 @@
-#!/usr/bin/execlineb -S0
+#!/command/execlineb -S0
 
 echo "cron exiting"
 s6-svscanctl -t /var/run/s6/services

--- a/rootfs/etc/services.d/cron/run
+++ b/rootfs/etc/services.d/cron/run
@@ -1,4 +1,4 @@
-#!/usr/bin/with-contenv bash
+#!/command/with-contenv bash
 
 echo "starting cron"
 cron -f -L 15

--- a/rootfs/etc/services.d/influxdb/run
+++ b/rootfs/etc/services.d/influxdb/run
@@ -1,4 +1,4 @@
-#!/usr/bin/with-contenv bash
+#!/command/with-contenv bash
 
 mkdir -p /opt/scrutiny/influxdb/
 

--- a/rootfs/etc/services.d/scrutiny/run
+++ b/rootfs/etc/services.d/scrutiny/run
@@ -1,4 +1,4 @@
-#!/usr/bin/with-contenv bash
+#!/command/with-contenv bash
 
 echo "waiting for influxdb"
 until $(curl --output /dev/null --silent --head --fail http://localhost:8086/health); do echo "influxdb not ready" && sleep 5; done


### PR DESCRIPTION
Updated s6overlay to v3
Note:  xz-utils was added as a requirement for s6-overlay (using safe 5.4.1 instead of compromised 5.6.x versions)
fixes #602