### PR TITLE
feat: create allow-list for filtering down devices to only a subset

### DIFF
--- a/collector/pkg/config/config.go
+++ b/collector/pkg/config/config.go
@@ -20,7 +20,7 @@ import (
 type configuration struct {
 	*viper.Viper
 
-	deviceOverrides []models.ScanOverride
+	deviceOverrides    []models.ScanOverride
 }
 
 //Viper uses the following precedence order. Each item takes precedence over the item below it:
@@ -49,6 +49,8 @@ func (c *configuration) Init() error {
 	c.SetDefault("commands.metrics_smart_args", "--xall --json")
 
 	//c.SetDefault("collect.short.command", "-a -o on -S on")
+
+	c.SetDefault("allow_listed_devices", []string{})
 
 	//if you want to load a non-standard location system config file (~/drawbridge.yml), use ReadConfig
 	c.SetConfigType("yaml")
@@ -185,4 +187,19 @@ func (c *configuration) GetCommandMetricsSmartArgs(deviceName string) string {
 		}
 	}
 	return c.GetString("commands.metrics_smart_args")
+}
+
+func (c *configuration) IsAllowlistedDevice(deviceName string) bool {
+	allowList := c.GetStringSlice("allow_listed_devices")
+	if len(allowList) == 0 {
+		return true
+	}
+
+	for _, item := range allowList {
+		if item == deviceName {
+			return true
+		}
+	}
+
+	return false
 }

--- a/collector/pkg/config/config_test.go
+++ b/collector/pkg/config/config_test.go
@@ -144,3 +144,29 @@ func TestConfiguration_OverrideDeviceCommands_MetricsInfoArgs(t *testing.T) {
 	require.Equal(t, "--info --json", testConfig.GetCommandMetricsInfoArgs("/dev/sdb"))
 	//require.Equal(t, []models.ScanOverride{{Device: "/dev/sda", DeviceType: nil, Commands: {MetricsInfoArgs: "--info --json -T "}}}, scanOverrides)
 }
+
+func TestConfiguration_DeviceAllowList(t *testing.T) {
+	t.Parallel()
+
+	t.Run("present", func(t *testing.T) {
+		testConfig, err := config.Create()
+		require.NoError(t, err)
+
+		require.NoError(t, testConfig.ReadConfig(path.Join("testdata", "allow_listed_devices_present.yaml")))
+
+		require.True(t, testConfig.IsAllowlistedDevice("/dev/sda"), "/dev/sda should be allow listed")
+		require.False(t, testConfig.IsAllowlistedDevice("/dev/sdc"), "/dev/sda should not be allow listed")
+	})
+
+	t.Run("missing", func(t *testing.T) {
+		testConfig, err := config.Create()
+		require.NoError(t, err)
+
+		// Really just any other config where the key is full missing
+		require.NoError(t, testConfig.ReadConfig(path.Join("testdata", "override_device_commands.yaml")))
+
+		// Anything should be allow listed if the key isnt there
+		require.True(t, testConfig.IsAllowlistedDevice("/dev/sda"), "/dev/sda should be allow listed")
+		require.True(t, testConfig.IsAllowlistedDevice("/dev/sdc"), "/dev/sda should be allow listed")
+	})
+}

--- a/collector/pkg/config/interface.go
+++ b/collector/pkg/config/interface.go
@@ -25,4 +25,6 @@ type Interface interface {
 	GetDeviceOverrides() []models.ScanOverride
 	GetCommandMetricsInfoArgs(deviceName string) string
 	GetCommandMetricsSmartArgs(deviceName string) string
+
+	IsAllowlistedDevice(deviceName string) bool
 }

--- a/collector/pkg/config/mock/mock_config.go
+++ b/collector/pkg/config/mock/mock_config.go
@@ -175,6 +175,20 @@ func (mr *MockInterfaceMockRecorder) Init() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Init", reflect.TypeOf((*MockInterface)(nil).Init))
 }
 
+// IsAllowlistedDevice mocks base method.
+func (m *MockInterface) IsAllowlistedDevice(deviceName string) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsAllowlistedDevice", deviceName)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsAllowlistedDevice indicates an expected call of IsAllowlistedDevice.
+func (mr *MockInterfaceMockRecorder) IsAllowlistedDevice(deviceName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsAllowlistedDevice", reflect.TypeOf((*MockInterface)(nil).IsAllowlistedDevice), deviceName)
+}
+
 // IsSet mocks base method.
 func (m *MockInterface) IsSet(key string) bool {
 	m.ctrl.T.Helper()

--- a/collector/pkg/config/testdata/allow_listed_devices_present.yaml
+++ b/collector/pkg/config/testdata/allow_listed_devices_present.yaml
@@ -1,0 +1,3 @@
+allow_listed_devices:
+- /dev/sda
+- /dev/sdb

--- a/collector/pkg/detect/detect.go
+++ b/collector/pkg/detect/detect.go
@@ -124,6 +124,11 @@ func (d *Detect) TransformDetectedDevices(detectedDeviceConns models.Scan) []mod
 
 		deviceFile := strings.ToLower(scannedDevice.Name)
 
+		// If the user has defined a device allow list, and this device isnt there, then ignore it
+		if !d.Config.IsAllowlistedDevice(deviceFile) {
+			continue
+		}
+
 		detectedDevice := models.Device{
 			HostId:     d.Config.GetString("host.id"),
 			DeviceType: scannedDevice.Type,


### PR DESCRIPTION
I'm trying to run Scrutiny in Kubernetes. My storage solution involves Longhorn. This means that not all drives are "real" so to speak, some of them are mounted due the fact that a certain pod is present on a host. These pods can move about, which means that disks can come and go.

![image](https://github.com/user-attachments/assets/49a9afc4-c87f-4216-95f7-f66af121872c)

In the above screen shotshot, only sda/sdb/sdc are real physical disks that are plugged into the system, sdd/sde are the result of pods. I would list scrutiny to only bother monitoring the "real" disks, thus an allow list to specify which ones. I cannot use the existing `devices` keyword, because as pods move around I could get more disks than what I have excluded, it would be an endless game of whack-a-mole to exclude the fake disks.

Thus, PR. 