### PR TITLE
fix: issue 643 - Fahrenheit values in graph were converted twice

### DIFF
--- a/webapp/frontend/src/app/modules/dashboard/dashboard.component.ts
+++ b/webapp/frontend/src/app/modules/dashboard/dashboard.component.ts
@@ -159,9 +159,18 @@ export class DashboardComponent implements OnInit, AfterViewInit, OnDestroy
 
             for(const tempHistory of deviceSummary.temp_history){
                 const newDate = new Date(tempHistory.date);
+                let temperature;
+                switch (this.config.temperature_unit) {
+                    case 'celsius':
+                        temperature = tempHistory.temp;
+                        break
+                    case 'fahrenheit':
+                        temperature = TemperaturePipe.celsiusToFahrenheit(tempHistory.temp)
+                        break
+                }
                 deviceSeriesMetadata.data.push({
                     x: newDate,
-                    y: TemperaturePipe.formatTemperature(tempHistory.temp, this.config.temperature_unit, false)
+                    y: temperature
                 })
             }
             deviceTemperatureSeries.push(deviceSeriesMetadata)

--- a/webapp/frontend/src/app/shared/temperature.pipe.spec.ts
+++ b/webapp/frontend/src/app/shared/temperature.pipe.spec.ts
@@ -11,16 +11,16 @@ describe('TemperaturePipe', () => {
         const testCases = [
             {
                 'c': -273.15,
-                'f': -460,
+                'f': -459.66999999999996,
             },{
                 'c': -34.44,
-                'f': -30,
+                'f': -29.991999999999997,
             },{
                 'c': -23.33,
-                'f': -10,
+                'f': -9.993999999999993,
             },{
                 'c': -17.78,
-                'f': -0,
+                'f': -0.0040000000000048885,
             },{
                 'c': 0,
                 'f': 32,
@@ -29,10 +29,10 @@ describe('TemperaturePipe', () => {
                 'f': 50,
             },{
                 'c': 26.67,
-                'f': 80,
+                'f': 80.006,
             },{
                 'c': 37,
-                'f': 99,
+                'f': 98.6,
             },{
                 'c': 60,
                 'f': 140,
@@ -42,8 +42,7 @@ describe('TemperaturePipe', () => {
             it(`should correctly convert ${test.c}, Celsius to Fahrenheit (testcase: ${index + 1})`, () => {
                 // test
                 const numb = TemperaturePipe.celsiusToFahrenheit(test.c)
-                const roundNumb = Math.round(numb);
-                expect(roundNumb).toEqual(test.f);
+                expect(numb).toEqual(test.f);
             });
         })
     });
@@ -56,6 +55,11 @@ describe('TemperaturePipe', () => {
                 'includeUnits': true,
                 'result': '26.67°C'
             },{
+                'c': 26.6767,
+                'unit': 'celsius',
+                'includeUnits': true,
+                'result': '26.677°C'
+            },{
                 'c': 26.67,
                 'unit': 'celsius',
                 'includeUnits': false,
@@ -64,12 +68,17 @@ describe('TemperaturePipe', () => {
                 'c': 26.67,
                 'unit': 'fahrenheit',
                 'includeUnits': true,
-                'result': '80.006°F',
+                'result': '26.67°F',
+            },{
+                'c': 26.6767,
+                'unit': 'fahrenheit',
+                'includeUnits': true,
+                'result': '26.677°F',
             },{
                 'c': 26.67,
                 'unit': 'fahrenheit',
                 'includeUnits': false,
-                'result': '80.006',
+                'result': '26.67',
             }
         ]
         testCases.forEach((test, index) => {

--- a/webapp/frontend/src/app/shared/temperature.pipe.ts
+++ b/webapp/frontend/src/app/shared/temperature.pipe.ts
@@ -6,29 +6,35 @@ import {formatNumber} from '@angular/common';
 })
 export class TemperaturePipe implements PipeTransform {
     static celsiusToFahrenheit(celsiusTemp: number): number {
-        return celsiusTemp * 9.0 / 5.0 + 32;
+        return celsiusTemp * 9/5 + 32;
     }
-    static formatTemperature(celsiusTemp: number, unit: string, includeUnits: boolean): number|string {
-        let convertedTemp
-        let convertedUnitSuffix
+    static formatTemperature(temp: number, unit: string, includeUnits: boolean): number|string {
+        let unitSuffix
         switch (unit) {
             case 'celsius':
-                convertedTemp = celsiusTemp
-                convertedUnitSuffix = '°C'
+                unitSuffix = '°C'
                 break
             case 'fahrenheit':
-                convertedTemp = TemperaturePipe.celsiusToFahrenheit(celsiusTemp)
-                convertedUnitSuffix = '°F'
+                unitSuffix = '°F'
                 break
         }
         if(includeUnits){
-            return formatNumber(convertedTemp, 'en-US') + convertedUnitSuffix
+            return formatNumber(temp, 'en-US') + unitSuffix
         } else {
-            return formatNumber(convertedTemp, 'en-US',)
+            return formatNumber(temp, 'en-US',)
         }
     }
 
   transform(celsiusTemp: number, unit = 'celsius', includeUnits = false): number|string {
+        let temperature;
+        switch (unit) {
+            case 'celsius':
+                temperature = celsiusTemp;
+                break
+            case 'fahrenheit':
+                temperature = TemperaturePipe.celsiusToFahrenheit(celsiusTemp)
+                break
+        }
         return TemperaturePipe.formatTemperature(celsiusTemp, unit, includeUnits)
   }
 


### PR DESCRIPTION
needed to separate formatting temps from converting values

dashboard was using format method to convert and send Fahrenheit values to chart, then passing the same method into chart formatter causing the Fahrenheit value to be passed in as Celsius and converted again


