### PR TITLE
Fix CI (conflicting artifact names)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -108,7 +108,7 @@ jobs:
       - name: Archive
         uses: actions/upload-artifact@v4
         with:
-          name: binaries.zip
+          name: binaries-${{ matrix.cfg.on }}-${{ matrix.cfg.goos }}-${{ matrix.cfg.goarch }}-${{ matrix.cfg.goarm || 'na' }}.zip
           path: |
             scrutiny-web-*
             scrutiny-collector-metrics-*


### PR DESCRIPTION
CI is currently broken because of a breaking change in upload-artifact@v4.
Unlike earlier versions of upload-artifact, uploading to the same artifact via multiple jobs is not supported with v4.

Documentation (https://github.com/actions/upload-artifact):

> In matrix scenarios, be careful to not accidentally upload to the same artifact, or else you will encounter conflict errors. It would be best to name the artifact with a prefix or suffix from the matrix:
> 
>     jobs:
>       upload:
>         name: Generate Build Artifacts
> 
>         strategy:
>           matrix:
>             os: [ubuntu-latest, windows-latest]
>             version: [a, b, c]
> 
>         runs-on: ${{ matrix.os }}
> 
>         steps:
>         - name: Build
>           run: ./some-script --version=${{ matrix.version }} > my-binary
>         - name: Upload
>           uses: actions/upload-artifact@v4
>           with:
>             name: binary-${{ matrix.os }}-${{ matrix.version }}
>             path: my-binary
> 
> This will result in artifacts like: binary-ubuntu-latest-a, binary-windows-latest-b, and so on.

I did the same fix in my other PR https://github.com/AnalogJ/scrutiny/pull/557#issuecomment-2585169972 but as this isn't related, I opened another dedicated PR.