### PR TITLE
fix: try to unmarshal `notify.url` and use it when needed

### DIFF
--- a/webapp/backend/pkg/notify/notify.go
+++ b/webapp/backend/pkg/notify/notify.go
@@ -229,6 +229,13 @@ func (n *Notify) Send() error {
 
 	//retrieve list of notification endpoints from config file
 	configUrls := n.Config.GetStringSlice("notify.urls")
+	configString := n.Config.GetString("notify.urls")
+	var jsonConfig []string
+	err := json.Unmarshal([]byte(configString), &jsonConfig)
+	if err == nil {
+		configUrls = jsonConfig
+	}
+
 	n.Logger.Debugf("Configured notification services: %v", configUrls)
 
 	if len(configUrls) == 0 {


### PR DESCRIPTION
This PR fix the `first path segment in URL cannot contain colon` when passing notifier to scrutiny through `env` variables.

Per the [doc](https://github.com/AnalogJ/scrutiny/blob/a58f9445c13c314829dbe162cbb29c58dba2bbbc/docs/INSTALL_HUB_SPOKE.md?plain=1#L94), environment-given notifier URLs should be contained in a json array. However, this feature does not work at the time.

To fix this issue, I added a `json.unmarshal` on `notify.urls` config string. The configuration string is only replaced if the unmarshal has no error, ensuring backward compatibility.

*Note: I only tested this feature with the docker image, and not the binary. Ensuring the binary work before merging would be best.*

This PR closes #745.

Also, thanks for the good work !