### PR TITLE
Unify docker restart policy among docs and example files

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ If you're using Docker, getting started is as simple as running the following co
 > See [docker/example.omnibus.docker-compose.yml](https://github.com/AnalogJ/scrutiny/blob/master/docker/example.omnibus.docker-compose.yml) for a docker-compose file.
 
 ```bash
-docker run -it --rm -p 8080:8080 -p 8086:8086 \
+docker run -p 8080:8080 -p 8086:8086 --restart unless-stopped \
   -v `pwd`/scrutiny:/opt/scrutiny/config \
   -v `pwd`/influxdb2:/opt/scrutiny/influxdb \
   -v /run/udev:/run/udev:ro \
@@ -103,17 +103,17 @@ other Docker images:
 > See [docker/example.hubspoke.docker-compose.yml](https://github.com/AnalogJ/scrutiny/blob/master/docker/example.hubspoke.docker-compose.yml) for a docker-compose file.
 
 ```bash
-docker run --rm -p 8086:8086 \
+docker run -p 8086:8086 --restart unless-stopped \
   -v `pwd`/influxdb2:/var/lib/influxdb2 \
   --name scrutiny-influxdb \
   influxdb:2.2
 
-docker run --rm -p 8080:8080 \
+docker run -p 8080:8080 --restart unless-stopped \
   -v `pwd`/scrutiny:/opt/scrutiny/config \
   --name scrutiny-web \
   ghcr.io/analogj/scrutiny:master-web
 
-docker run --rm \
+docker run --restart unless-stopped \
   -v /run/udev:/run/udev:ro \
   --cap-add SYS_RAWIO \
   --device=/dev/sda \

--- a/docker/example.hubspoke.docker-compose.yml
+++ b/docker/example.hubspoke.docker-compose.yml
@@ -2,6 +2,7 @@ version: '2.4'
 
 services:
   influxdb:
+    restart: unless-stopped
     image: influxdb:2.2
     ports:
       - '8086:8086'
@@ -15,6 +16,7 @@ services:
 
 
   web:
+    restart: unless-stopped
     image: 'ghcr.io/analogj/scrutiny:master-web'
     ports:
       - '8080:8080'
@@ -33,6 +35,7 @@ services:
       start_period: 10s
 
   collector:
+    restart: unless-stopped
     image: 'ghcr.io/analogj/scrutiny:master-collector'
     cap_add:
       - SYS_RAWIO

--- a/docker/example.omnibus.docker-compose.yml
+++ b/docker/example.omnibus.docker-compose.yml
@@ -2,6 +2,7 @@ version: '3.5'
 
 services:
   scrutiny:
+    restart: unless-stopped
     container_name: scrutiny
     image: ghcr.io/analogj/scrutiny:master-omnibus
     cap_add:

--- a/docs/INSTALL_HUB_SPOKE.md
+++ b/docs/INSTALL_HUB_SPOKE.md
@@ -59,6 +59,7 @@ networks:
 
 services:
   influxdb:
+    restart: unless-stopped
     container_name: influxdb
     image: influxdb:2.1-alpine
     ports:
@@ -73,11 +74,11 @@ services:
       - DOCKER_INFLUXDB_INIT_ORG=homelab
       - DOCKER_INFLUXDB_INIT_BUCKET=scrutiny
       - DOCKER_INFLUXDB_INIT_ADMIN_TOKEN=your-very-secret-token
-    restart: unless-stopped
     networks:
       - monitoring
 
   scrutiny:
+    restart: unless-stopped
     container_name: scrutiny
     image: ghcr.io/analogj/scrutiny:master-web
     ports:
@@ -94,7 +95,6 @@ services:
       - SCRUTINY_NOTIFY_URLS=["http://gotify:80/message?token=a-gotify-token"]
     depends_on:
       - influxdb
-    restart: unless-stopped
     networks:
       - notifications
       - monitoring
@@ -168,6 +168,7 @@ version: "3.4"
 services:
 
   collector:
+    restart: unless-stopped
     image: 'ghcr.io/analogj/scrutiny:master-collector'
     cap_add:
       - SYS_RAWIO


### PR DESCRIPTION
This makes sure the services start up again after a reboot which is kind of important.
I also removed certain flags like `--rm` or `-it` where I thought they were misplaced.