### PR TITLE
Keep existing device type

### DIFF
--- a/collector/pkg/detect/detect.go
+++ b/collector/pkg/detect/detect.go
@@ -84,7 +84,6 @@ func (d *Detect) SmartCtlInfo(device *models.Device) error {
 	device.RotationSpeed = availableDeviceInfo.RotationRate
 	device.Capacity = availableDeviceInfo.Capacity()
 	device.FormFactor = availableDeviceInfo.FormFactor.Name
-	device.DeviceType = availableDeviceInfo.Device.Type
 	device.DeviceProtocol = availableDeviceInfo.Device.Protocol
 	if len(availableDeviceInfo.Vendor) > 0 {
 		device.Manufacturer = availableDeviceInfo.Vendor

--- a/collector/pkg/detect/detect.go
+++ b/collector/pkg/detect/detect.go
@@ -85,7 +85,12 @@ func (d *Detect) SmartCtlInfo(device *models.Device) error {
 	device.Capacity = availableDeviceInfo.Capacity()
 	device.FormFactor = availableDeviceInfo.FormFactor.Name
 	device.SmartSupport = availableDeviceInfo.SmartSupport.Supported()
-	device.DeviceType = availableDeviceInfo.Device.Type
+	// only fill in the type when nothing else supplied one: smartctl reports the
+	// transport it resolved to (eg. "sat"), not the addressing path we passed in
+	// (eg. "aacraid,0,0,1"), so overwriting here breaks collection on RAID members.
+	if len(device.DeviceType) == 0 {
+		device.DeviceType = availableDeviceInfo.Device.Type
+	}
 	device.DeviceProtocol = availableDeviceInfo.Device.Protocol
 	if len(availableDeviceInfo.Vendor) > 0 {
 		device.Manufacturer = availableDeviceInfo.Vendor

--- a/collector/pkg/detect/detect_test.go
+++ b/collector/pkg/detect/detect_test.go
@@ -439,6 +439,55 @@ func TestDetect_SmartCtlInfo(t *testing.T) {
 		assert.Equal(t, someCapacity, someDevice.Capacity)
 	})
 
+	t.Run("should keep the configured device type", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+
+		const (
+			someArgs = "--info --json"
+
+			someDeviceName = "sda"
+			// raid members are addressed via the controller; smartctl reports "sat"
+			someDeviceType = "aacraid,0,0,1"
+		)
+
+		fullDeviceName := detect.DevicePrefix() + someDeviceName
+
+		fakeConfig := mock_config.NewMockInterface(ctrl)
+		fakeConfig.EXPECT().
+			GetCommandMetricsInfoArgs(fullDeviceName).
+			Return(someArgs)
+		fakeConfig.EXPECT().
+			GetString("commands.metrics_smartctl_bin").
+			Return("smartctl")
+
+		someLogger := logrus.WithFields(logrus.Fields{})
+
+		smartctlInfoResults, err := os.ReadFile("testdata/smartctl_info_sata_smart_support_bool.json")
+		require.NoError(t, err)
+
+		expectedArgs := append(strings.Split(someArgs, " "), "--device", someDeviceType, fullDeviceName)
+
+		fakeShell := mock_shell.NewMockInterface(ctrl)
+		fakeShell.EXPECT().
+			Command(someLogger, "smartctl", expectedArgs, "", gomock.Any()).
+			Return(string(smartctlInfoResults), nil)
+
+		d := detect.Detect{
+			Logger: someLogger,
+			Shell:  fakeShell,
+			Config: fakeConfig,
+		}
+
+		someDevice := &models.Device{
+			DeviceName: someDeviceName,
+			DeviceType: someDeviceType,
+		}
+
+		require.NoError(t, d.SmartCtlInfo(someDevice))
+
+		assert.Equal(t, someDeviceType, someDevice.DeviceType)
+	})
+
 	for _, tt := range []struct {
 		name     string
 		filename string


### PR DESCRIPTION
This should fix #608 as it was overriding a configured device type from the `collector.yaml` with the (in my case wrong) results from the `smartctl --info` command (`device.type` JSON element).