### PR TITLE
Limit Zulip subject length and add URL topic override

### DIFF
--- a/webapp/backend/pkg/notify/notify.go
+++ b/webapp/backend/pkg/notify/notify.go
@@ -428,8 +428,8 @@ func (n *Notify) GenShoutrrrNotificationParams(shoutrrrUrl string) (string, *sho
 			subject = subject[:60]
 		}
 		urlTopic := serviceURL.Query()["force_topic"]
-		if urlTopic != "" {
-			subject = urlTopic
+		if len(urlTopic) > 0 && urlTopic[len(urlTopic)-1] != "" {
+			subject = urlTopic[len(urlTopic)-1]
 		}
 		(*params)["topic"] = subject
 	}

--- a/webapp/backend/pkg/notify/notify.go
+++ b/webapp/backend/pkg/notify/notify.go
@@ -424,6 +424,13 @@ func (n *Notify) GenShoutrrrNotificationParams(shoutrrrUrl string) (string, *sho
 	case "telegram":
 		(*params)["title"] = subject
 	case "zulip":
+		if len(subject) > 60 {
+			subject = subject[:60]
+		}
+		urlTopic := serviceURL.Query()["force_topic"]
+		if urlTopic != "" {
+			subject = urlTopic
+		}
 		(*params)["topic"] = subject
 	}
 

--- a/webapp/backend/pkg/notify/notify.go
+++ b/webapp/backend/pkg/notify/notify.go
@@ -424,7 +424,7 @@ func (n *Notify) GenShoutrrrNotificationParams(shoutrrrUrl string) (string, *sho
 	case "telegram":
 		(*params)["title"] = subject
 	case "zulip":
-		subjectRunes = []rune(subject)
+		subjectRunes := []rune(subject)
 		if len(subjectRunes) > 60 {
 			n.Logger.Warningf("Zulip notification subject too long (%d characters), truncating to 60 characters", len(subjectRunes))
 			subject = string(subjectRunes[:60])

--- a/webapp/backend/pkg/notify/notify.go
+++ b/webapp/backend/pkg/notify/notify.go
@@ -424,14 +424,16 @@ func (n *Notify) GenShoutrrrNotificationParams(shoutrrrUrl string) (string, *sho
 	case "telegram":
 		(*params)["title"] = subject
 	case "zulip":
+		query := serviceURL.Query()
+		urlTopic := query["topic"]
+		delete(query, "topic")
+		if len(urlTopic) > 0 && urlTopic[len(urlTopic)-1] != "" {
+			subject = urlTopic[len(urlTopic)-1]
+		}
 		subjectRunes := []rune(subject)
 		if len(subjectRunes) > 60 {
 			n.Logger.Warningf("Zulip notification subject too long (%d characters), truncating to 60 characters", len(subjectRunes))
 			subject = string(subjectRunes[:60])
-		}
-		urlTopic := serviceURL.Query()["force_topic"]
-		if len(urlTopic) > 0 && urlTopic[len(urlTopic)-1] != "" {
-			subject = urlTopic[len(urlTopic)-1]
 		}
 		(*params)["topic"] = subject
 	}

--- a/webapp/backend/pkg/notify/notify.go
+++ b/webapp/backend/pkg/notify/notify.go
@@ -424,8 +424,10 @@ func (n *Notify) GenShoutrrrNotificationParams(shoutrrrUrl string) (string, *sho
 	case "telegram":
 		(*params)["title"] = subject
 	case "zulip":
-		if len(subject) > 60 {
-			subject = subject[:60]
+		subjectRunes = []rune(subject)
+		if len(subjectRunes) > 60 {
+			n.Logger.Warningf("Zulip notification subject too long (%d characters), truncating to 60 characters", len(subjectRunes))
+			subject = string(subjectRunes[:60])
 		}
 		urlTopic := serviceURL.Query()["force_topic"]
 		if len(urlTopic) > 0 && urlTopic[len(urlTopic)-1] != "" {


### PR DESCRIPTION
Subjects over 60 characters long, such as the test notification, are rejected by shoutrrr. This truncates the subject to the max length.

Users may want all Scrutiny notifications to be sent to a particular topic rather than whatever Scrutiny happens to decide. This adds the ability to specify a `force_topic` URL parameter to specify that.