### PR TITLE
Implement device-wise notification mute/unmute

### DIFF
--- a/webapp/backend/pkg/database/interface.go
+++ b/webapp/backend/pkg/database/interface.go
@@ -21,6 +21,7 @@ type DeviceRepo interface {
 	UpdateDeviceStatus(ctx context.Context, wwn string, status pkg.DeviceStatus) (models.Device, error)
 	GetDeviceDetails(ctx context.Context, wwn string) (models.Device, error)
 	UpdateDeviceArchived(ctx context.Context, wwn string, archived bool) error
+        UpdateDeviceMuted(ctx context.Context, wwn string, archived bool) error
 	DeleteDevice(ctx context.Context, wwn string) error
 
 	SaveSmartAttributes(ctx context.Context, wwn string, collectorSmartData collector.SmartInfo) (measurements.Smart, error)

--- a/webapp/backend/pkg/database/migrations/m20251108044508/device.go
+++ b/webapp/backend/pkg/database/migrations/m20251108044508/device.go
@@ -1,14 +1,15 @@
-package m20250221084400
+package m20251108044508
 
 import (
 	"github.com/analogj/scrutiny/webapp/backend/pkg"
 	"time"
 )
 
+
 type Device struct {
 	//GORM attributes, see: http://gorm.io/docs/conventions.html
 	Archived bool `json:"archived"`
-	Muted   bool  `json:muted`
+	Muted	 bool `json:muted`
 	CreatedAt time.Time
 	UpdatedAt time.Time
 	DeletedAt *time.Time

--- a/webapp/backend/pkg/database/mock/mock_database.go
+++ b/webapp/backend/pkg/database/mock/mock_database.go
@@ -66,6 +66,20 @@ func (mr *MockDeviceRepoMockRecorder) UpdateDeviceArchived(ctx, wwn, archived in
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateDeviceArchived", reflect.TypeOf((*MockDeviceRepo)(nil).UpdateDeviceArchived), ctx, wwn, archived)
 }
 
+// UpdateDeviceMuted mocks base method.
+func (m *MockDeviceRepo) UpdateDeviceMuted(ctx context.Context, wwn string, archived bool) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateDeviceMuted", ctx, wwn)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateDeviceMuted indicates an expected call of UpdateDeviceMuted.
+func (mr *MockDeviceRepoMockRecorder) UpdateDeviceMuted(ctx, wwn, archived interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateDeviceMuted", reflect.TypeOf((*MockDeviceRepo)(nil).UpdateDeviceMuted), ctx, wwn, archived)
+}
+
 // DeleteDevice mocks base method.
 func (m *MockDeviceRepo) DeleteDevice(ctx context.Context, wwn string) error {
 	m.ctrl.T.Helper()

--- a/webapp/backend/pkg/database/scrutiny_repository_device.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_device.go
@@ -84,6 +84,16 @@ func (sr *scrutinyRepository) UpdateDeviceArchived(ctx context.Context, wwn stri
 	return sr.gormClient.Model(&device).Where("wwn = ?", wwn).Update("archived", archived).Error
 }
 
+// Update Device Muted State
+func (sr *scrutinyRepository) UpdateDeviceMuted(ctx context.Context, wwn string, muted bool) error {
+	var device models.Device
+	if err := sr.gormClient.WithContext(ctx).Where("wwn = ?", wwn).First(&device).Error; err != nil {
+		return fmt.Errorf("Could not get device from DB: %v", err)
+	}
+
+	return sr.gormClient.Model(&device).Where("wwn = ?", wwn).Update("muted", muted).Error
+}
+
 func (sr *scrutinyRepository) DeleteDevice(ctx context.Context, wwn string) error {
 	if err := sr.gormClient.WithContext(ctx).Where("wwn = ?", wwn).Delete(&models.Device{}).Error; err != nil {
 		return err

--- a/webapp/backend/pkg/database/scrutiny_repository_migrations.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_migrations.go
@@ -13,6 +13,7 @@ import (
 	"github.com/analogj/scrutiny/webapp/backend/pkg/database/migrations/m20220509170100"
 	"github.com/analogj/scrutiny/webapp/backend/pkg/database/migrations/m20220716214900"
 	"github.com/analogj/scrutiny/webapp/backend/pkg/database/migrations/m20250221084400"
+	"github.com/analogj/scrutiny/webapp/backend/pkg/database/migrations/m20251108044508"
 	"github.com/analogj/scrutiny/webapp/backend/pkg/models"
 	"github.com/analogj/scrutiny/webapp/backend/pkg/models/collector"
 	"github.com/analogj/scrutiny/webapp/backend/pkg/models/measurements"
@@ -407,6 +408,15 @@ func (sr *scrutinyRepository) Migrate(ctx context.Context) error {
 				//migrate the device database.
 				// adding column (archived)
 				return tx.AutoMigrate(m20250221084400.Device{})
+			},
+		},
+		{
+			ID: "m20251108044508", // add archived to device data
+			Migrate: func(tx *gorm.DB) error {
+
+				//migrate the device database.
+				// adding column (muted)
+				return tx.AutoMigrate(m20251108044508.Device{})
 			},
 		},
 	})

--- a/webapp/backend/pkg/models/device.go
+++ b/webapp/backend/pkg/models/device.go
@@ -15,6 +15,7 @@ type DeviceWrapper struct {
 type Device struct {
 	//GORM attributes, see: http://gorm.io/docs/conventions.html
 	Archived  bool `json:"archived"`
+	Muted     bool `json:"muted"`
 	CreatedAt time.Time
 	UpdatedAt time.Time
 	DeletedAt *time.Time

--- a/webapp/backend/pkg/notify/notify.go
+++ b/webapp/backend/pkg/notify/notify.go
@@ -38,6 +38,11 @@ func ShouldNotify(logger logrus.FieldLogger, device models.Device, smartAttrs me
 		return false
 	}
 
+	// If the device is muted, skip notification regardless of status
+	if device.Muted {
+		return false
+	}
+
 	//TODO: cannot check for warning notifyLevel yet.
 
 	// setup constants for comparison

--- a/webapp/backend/pkg/web/handler/mute_device.go
+++ b/webapp/backend/pkg/web/handler/mute_device.go
@@ -1,0 +1,22 @@
+package handler
+
+import (
+	"github.com/analogj/scrutiny/webapp/backend/pkg/database"
+	"github.com/gin-gonic/gin"
+	"github.com/sirupsen/logrus"
+	"net/http"
+)
+
+func MuteDevice(c *gin.Context) {
+	logger := c.MustGet("LOGGER").(*logrus.Entry)
+	deviceRepo := c.MustGet("DEVICE_REPOSITORY").(database.DeviceRepo)
+
+	err := deviceRepo.UpdateDeviceMuted(c, c.Param("wwn"), true)
+	if err != nil {
+		logger.Errorln("An error occurred while muting device", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"success": false})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"success": true})
+}

--- a/webapp/backend/pkg/web/handler/unmute_device.go
+++ b/webapp/backend/pkg/web/handler/unmute_device.go
@@ -1,0 +1,22 @@
+package handler
+
+import (
+	"github.com/analogj/scrutiny/webapp/backend/pkg/database"
+	"github.com/gin-gonic/gin"
+	"github.com/sirupsen/logrus"
+	"net/http"
+)
+
+func UnmuteDevice(c *gin.Context) {
+	logger := c.MustGet("LOGGER").(*logrus.Entry)
+	deviceRepo := c.MustGet("DEVICE_REPOSITORY").(database.DeviceRepo)
+
+	err := deviceRepo.UpdateDeviceMuted(c, c.Param("wwn"), false)
+	if err != nil {
+		logger.Errorln("An error occurred while muting device", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"success": false})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"success": true})
+}

--- a/webapp/backend/pkg/web/server.go
+++ b/webapp/backend/pkg/web/server.go
@@ -45,6 +45,8 @@ func (ae *AppEngine) Setup(logger *logrus.Entry) *gin.Engine {
 			api.GET("/device/:wwn/details", handler.GetDeviceDetails)   //used by Details
 			api.POST("/device/:wwn/archive", handler.ArchiveDevice)     //used by UI to archive device
 			api.POST("/device/:wwn/unarchive", handler.UnarchiveDevice) //used by UI to unarchive device
+			api.POST("/device/:wwn/mute", handler.MuteDevice)           //used by UI to mute device
+			api.POST("/device/:wwn/unmute", handler.UnmuteDevice)       //used by UI to unmute device
 			api.DELETE("/device/:wwn", handler.DeleteDevice)            //used by UI to delete device
 
 			api.GET("/settings", handler.GetSettings)   //used to get settings

--- a/webapp/frontend/src/app/core/models/device-model.ts
+++ b/webapp/frontend/src/app/core/models/device-model.ts
@@ -1,6 +1,7 @@
 // maps to webapp/backend/pkg/models/device.go
 export interface DeviceModel {
     archived?: boolean;
+    muted: boolean;
     wwn: string;
     device_name?: string;
     device_uuid?: string;

--- a/webapp/frontend/src/app/layout/common/dashboard-device/dashboard-device.component.html
+++ b/webapp/frontend/src/app/layout/common/dashboard-device/dashboard-device.component.html
@@ -17,7 +17,11 @@
     <div class="flex items-center">
         <div class="flex flex-col">
             <a [routerLink]="'/device/'+ deviceSummary.device.wwn"
-               class="font-bold text-md text-secondary uppercase tracking-wider">{{deviceSummary.device | deviceTitle:config.dashboard_display}}</a>
+               class="font-bold text-md text-secondary uppercase tracking-wider">{{deviceSummary.device | deviceTitle:config.dashboard_display}} <mat-icon
+                 [svgIcon]="'notifications_off'"
+                 *ngIf="deviceSummary.device.muted"
+                 class="muted-icon"
+               ></mat-icon></a>
             <div [ngClass]="classDeviceLastUpdatedOn(deviceSummary)" class="font-medium text-sm" *ngIf="deviceSummary.smart">
                 Last Updated on {{deviceSummary.smart.collector_date | date:'MMMM dd, yyyy - HH:mm' }}
             </div>

--- a/webapp/frontend/src/app/layout/common/dashboard-device/dashboard-device.component.scss
+++ b/webapp/frontend/src/app/layout/common/dashboard-device/dashboard-device.component.scss
@@ -1,3 +1,21 @@
 .text-disabled{
     opacity: 0.8;
 }
+
+.mat-icon.muted-icon {
+    /* Treo is messing with the selector a little bit, so we have to assert !importance here */
+    display: inline-block !important;
+    width: 16px;
+    height: 16px;
+    min-width: 16px;
+    min-height: 16px;
+
+    // This gives a slightly better alignment on default zoom.
+    // Need to figure out a better way. See comment in app/modules/detail/detail.component.scss
+    vertical-align: middle;
+}
+
+.mat-icon.muted-icon {
+    width: 16px;
+    height: 16px;
+}

--- a/webapp/frontend/src/app/layout/common/detail-settings/detail-settings.component.html
+++ b/webapp/frontend/src/app/layout/common/detail-settings/detail-settings.component.html
@@ -15,9 +15,9 @@
         <div class="flex flex-col gt-xs:flex-row">
             <mat-form-field class="flex-auto gt-xs:pr-3">
                 <mat-label>Notifications</mat-label>
-                <mat-select [value]="'enable'">
-                    <mat-option  value="enable">Enabled</mat-option>
-                    <mat-option value="disable" disabled>Disabled</mat-option>
+                <mat-select [(value)]="muted">
+                    <mat-option [value]="false">Enabled</mat-option>
+                    <mat-option [value]="true">Disabled</mat-option>
                 </mat-select>
             </mat-form-field>
         </div>
@@ -26,5 +26,5 @@
 </mat-dialog-content>
 <mat-dialog-actions align="end">
     <button mat-button mat-dialog-close>Cancel</button>
-    <button mat-button matTooltip="not yet implemented" [mat-dialog-close]="true" cdkFocusInitial>Save</button>
+    <button mat-button [mat-dialog-close]="{ muted }" cdkFocusInitial>Save</button>
 </mat-dialog-actions>

--- a/webapp/frontend/src/app/layout/common/detail-settings/detail-settings.component.ts
+++ b/webapp/frontend/src/app/layout/common/detail-settings/detail-settings.component.ts
@@ -1,4 +1,5 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, Inject } from '@angular/core';
+import { MAT_DIALOG_DATA } from '@angular/material/dialog';
 
 @Component({
   selector: 'app-detail-settings',
@@ -7,9 +8,14 @@ import { Component, OnInit } from '@angular/core';
 })
 export class DetailSettingsComponent implements OnInit {
 
-  constructor() { }
+  muted: boolean;
+
+  constructor(
+      @Inject(MAT_DIALOG_DATA) public data: { curMuted: boolean }
+  ) {
+      this.muted = data.curMuted;
+  }
 
   ngOnInit(): void {
   }
-
 }

--- a/webapp/frontend/src/app/modules/detail/detail.component.html
+++ b/webapp/frontend/src/app/modules/detail/detail.component.html
@@ -4,20 +4,25 @@
 
         <div class="flex items-center justify-between w-full my-4 px-4 xs:pr-0">
             <div class="mr-6">
-                <h2 class="m-0">Drive Details - {{device | deviceTitle:config.dashboard_display}} </h2>
+                <h2 class="m-0">Drive Details - {{device | deviceTitle:config.dashboard_display}} <mat-icon
+                    [svgIcon]="'notifications_off'"
+                    *ngIf="device && device.muted"
+                    class="muted-icon"
+                ></mat-icon></h2>
                 <div class="text-secondary tracking-tight">Dive into S.M.A.R.T data</div>
             </div>
             <!-- Action buttons -->
             <div class="flex items-center">
-                <button class="xs:hidden"
+                <button class="ml-2 xs:hidden"
                         matTooltip="not yet implemented"
                         mat-stroked-button>
                     <mat-icon class="icon-size-20"
                               [svgIcon]="'save'"></mat-icon>
                     <span class="ml-2">Export</span>
                 </button>
+
                 <button class="ml-2 xs:hidden"
-                        matTooltip="not yet implemented"
+                        (click)="openSettingsDialog()"
                         mat-stroked-button>
                     <mat-icon class="icon-size-20 rotate-90 mirror"
                               [svgIcon]="'tune'"></mat-icon>
@@ -38,7 +43,7 @@
                             <span class="ml-2">Export</span>
                         </button>
                         <button mat-menu-item
-                                (click)="openDialog()">
+                                (click)="openSettingsDialog()">
                             <mat-icon class="icon-size-20 rotate-90 mirror"
                                       [svgIcon]="'tune'"></mat-icon>
                             <span class="ml-2">Settings</span>

--- a/webapp/frontend/src/app/modules/detail/detail.component.scss
+++ b/webapp/frontend/src/app/modules/detail/detail.component.scss
@@ -51,3 +51,10 @@ tr.attribute-row:not(.attribute-expanded-row):active {
     overflow: hidden;
     display: flex;
 }
+
+.muted-icon {
+    // Giving vertical-align does not solve alignment for all optical font sizes.
+    // Actually aligning by baseline shows a more decent alignment on default zoom on Firefox w/ Inter
+    // Commenting this out for now. Need to figure out a better way.
+    // vertical-align: middle;
+}

--- a/webapp/frontend/src/app/modules/detail/detail.component.ts
+++ b/webapp/frontend/src/app/modules/detail/detail.component.ts
@@ -439,11 +439,21 @@ export class DetailComponent implements OnInit, AfterViewInit, OnDestroy {
         this.smartAttributeDataSource.data = this._generateSmartAttributeTableDataSource(this.smart_results);
     }
 
-    openDialog(): void {
-        const dialogRef = this.dialog.open(DetailSettingsComponent);
+    openSettingsDialog(): void {
+        const dialogRef = this.dialog.open(DetailSettingsComponent, {
+            data: {
+                curMuted: this.device.muted
+            },
+        });
 
-        dialogRef.afterClosed().subscribe(result => {
-            console.log(`Dialog result: ${result}`);
+        dialogRef.afterClosed().subscribe((result: undefined | null | { muted: boolean }) => {
+            console.log('Settings dialog result', result);
+            if (!result) return;
+            if (result.muted !== this.device.muted) {
+                this._detailService.setMuted(this.device.wwn, result.muted).toPromise().then(() => {
+                    return this._detailService.getData(this.device.wwn).toPromise();
+                });
+            }
         });
     }
 

--- a/webapp/frontend/src/app/modules/detail/detail.service.ts
+++ b/webapp/frontend/src/app/modules/detail/detail.service.ts
@@ -49,4 +49,13 @@ export class DetailService {
             })
         );
     }
+
+    /**
+     * Mute / Unmute certain device
+     */
+    setMuted(wwn, muted): Observable<any> {
+        console.log('Set muted', muted);
+        const action = muted ? 'mute' : 'unmute';
+        return this._httpClient.post(getBasePath() + `/api/device/${wwn}/${action}`, {});
+    }
 }


### PR DESCRIPTION
Muting notification for a certain device may be helpful in certain cases, such as when a degraded drive is waiting for replacement. This PR adds the backend and frontend changes for muting a device.

It's a pleasant surprise that a setting dialog containing a "notification" entry in the device detail page is already present. This PR reuse that dialog.

## Changes
- Added a column `mute: boolean` to the `device` table.
- For devices with `mute = true`, skip notification.
- Added two endpoints: `/device/:wwn/mute` and `/device/:wwn/unmute` for setting the mute status in devices.
- Implement the "Notification" entry in the device detail settings dialog.
- Enable the settings dialog in wide screen.
- Added a "mute" icon in the device detail page and dashboard card for muted devices.

## Future works

Implementation presented in this PR has some shortcomings:

- I'm rather new to Angular, so the handling of state updates are a little sloppy. Right now the following actions happens sequentially: \
  The dialog closes.  -> Send update request -> Refresh drive data \
  One may see some opportunity for races here. However races does not introduce any inconsistency state, so no additional locking is done in this PR.
- Alignment of the muted icon is incorrect with some page zooms. Ideally we'd want a icon-font with `line-height` as its means of vertical aligning, but that means we'll bundle a icon font.
- Maybe instead of a device-wise mute, a attribute-wise mute is better?
- There is no tests whatsoever

## Screenshots
<img width="1716" height="523" alt="image" src="https://github.com/user-attachments/assets/c2bf7f87-1bb1-42e6-b37a-f811b173a99d" />
<img width="860" height="489" alt="image" src="https://github.com/user-attachments/assets/27993793-b3ec-4572-bbac-11f2df255614" />
