### PR TITLE
Add "day" as a option for range in the temperature graph

### DIFF
--- a/webapp/backend/pkg/database/scrutiny_repository.go
+++ b/webapp/backend/pkg/database/scrutiny_repository.go
@@ -30,6 +30,7 @@ const (
 	// 60seconds * 60minutes * 24hours * 7 days * (52 + 52 + 4)weeks
 	RETENTION_PERIOD_25_MONTHS_IN_SECONDS = 65_318_400
 
+	DURATION_KEY_DAY     = "day"
 	DURATION_KEY_WEEK    = "week"
 	DURATION_KEY_MONTH   = "month"
 	DURATION_KEY_YEAR    = "year"
@@ -446,6 +447,7 @@ func (sr *scrutinyRepository) GetSummary(ctx context.Context) (map[string]*model
 
 func (sr *scrutinyRepository) lookupBucketName(durationKey string) string {
 	switch durationKey {
+	case DURATION_KEY_DAY:
 	case DURATION_KEY_WEEK:
 		//data stored in the last week
 		return sr.appConfig.GetString("web.influxdb.bucket")
@@ -463,8 +465,10 @@ func (sr *scrutinyRepository) lookupBucketName(durationKey string) string {
 }
 
 func (sr *scrutinyRepository) lookupDuration(durationKey string) []string {
-
 	switch durationKey {
+	case DURATION_KEY_DAY:
+		//data stored in the last day
+		return []string{"-1d", "now()"}
 	case DURATION_KEY_WEEK:
 		//data stored in the last week
 		return []string{"-1w", "now()"}
@@ -481,8 +485,22 @@ func (sr *scrutinyRepository) lookupDuration(durationKey string) []string {
 	return []string{"-1w", "now()"}
 }
 
+func (sr *scrutinyRepository) lookupResolution(durationKey string) string {
+	switch durationKey {
+	case DURATION_KEY_DAY:
+		// Return data with higher resolution for daily summaries
+		return "10m"
+	default:
+		// Return data with 1h resolution for other summaries
+		return "1h"
+	}
+}
+
 func (sr *scrutinyRepository) lookupNestedDurationKeys(durationKey string) []string {
 	switch durationKey {
+	case DURATION_KEY_DAY:
+		//all data is stored in a single bucket, but we want a finer resolution
+		return []string{DURATION_KEY_DAY}
 	case DURATION_KEY_WEEK:
 		//all data is stored in a single bucket
 		return []string{DURATION_KEY_WEEK}

--- a/webapp/backend/pkg/database/scrutiny_repository_temperature.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_temperature.go
@@ -140,13 +140,14 @@ func (sr *scrutinyRepository) aggregateTempQuery(durationKey string) string {
 	for _, nestedDurationKey := range nestedDurationKeys {
 		bucketName := sr.lookupBucketName(nestedDurationKey)
 		durationRange := sr.lookupDuration(nestedDurationKey)
+		durationResolution := sr.lookupResolution(nestedDurationKey)
 
 		subQueryNames = append(subQueryNames, fmt.Sprintf(`%sData`, nestedDurationKey))
 		partialQueryStr = append(partialQueryStr, []string{
 			fmt.Sprintf(`%sData = from(bucket: "%s")`, nestedDurationKey, bucketName),
 			fmt.Sprintf(`|> range(start: %s, stop: %s)`, durationRange[0], durationRange[1]),
 			`|> filter(fn: (r) => r["_measurement"] == "temp" )`,
-			`|> aggregateWindow(every: 1h, fn: mean, createEmpty: false)`,
+			fmt.Sprintf(`|> aggregateWindow(every: %s, fn: mean, createEmpty: false)`, durationResolution),
 			`|> group(columns: ["device_wwn"])`,
 			`|> toInt()`,
 			"",

--- a/webapp/frontend/src/app/modules/dashboard/dashboard.component.html
+++ b/webapp/frontend/src/app/modules/dashboard/dashboard.component.html
@@ -96,6 +96,7 @@
                                     <button (click)="changeSummaryTempDuration('year')" mat-menu-item>year</button>
                                     <button (click)="changeSummaryTempDuration('month')" mat-menu-item>month</button>
                                     <button (click)="changeSummaryTempDuration('week')" mat-menu-item>week</button>
+                                    <button (click)="changeSummaryTempDuration('day')" mat-menu-item>day</button>
                                 </mat-menu>
                             </div>
                         </div>

--- a/webapp/frontend/src/app/modules/dashboard/dashboard.component.ts
+++ b/webapp/frontend/src/app/modules/dashboard/dashboard.component.ts
@@ -272,11 +272,11 @@ export class DashboardComponent implements OnInit, AfterViewInit, OnDestroy
     }
 
     /*
-
+    DURATION_KEY_DAY    = "day"
     DURATION_KEY_WEEK    = "week"
-	DURATION_KEY_MONTH   = "month"
-	DURATION_KEY_YEAR    = "year"
-	DURATION_KEY_FOREVER = "forever"
+    DURATION_KEY_MONTH   = "month"
+    DURATION_KEY_YEAR    = "year"
+    DURATION_KEY_FOREVER = "forever"
      */
 
     changeSummaryTempDuration(durationKey: string): void {


### PR DESCRIPTION
Now the dashboard can display daily temperature graph with slightly higher resolution (10m per point).

<img width="1223" height="341" alt="image" src="https://github.com/user-attachments/assets/518c90c3-a47e-4879-a75f-8a0c8d97146b" />

This PR **does not** change the database layout. The new duration key `DURATION_KEY_DAY = "day"` only affects the aggregate resolution, not the data source bucket or other nested queries.