### PR TITLE
Add missing mocks for frontend demo mode to work

### DIFF
--- a/webapp/frontend/src/@treo/lib/mock-api/mock-api.interceptor.ts
+++ b/webapp/frontend/src/@treo/lib/mock-api/mock-api.interceptor.ts
@@ -30,6 +30,18 @@ export class TreoMockApiInterceptor implements HttpInterceptor
     intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>>
     {
         // Try to get the request handler
+        let urlPath = request.url;
+
+        try
+        {
+            const url = new URL(request.url);
+            urlPath = url.pathname;
+        }
+        catch (e)
+        {
+            // relative URL, leave as-is
+        }
+
         const requestHandler: TreoMockApiRequestHandler = this._treoMockApiService.requestHandlers[request.method.toLowerCase()].get(request.url);
 
         // If the request handler exists..

--- a/webapp/frontend/src/@treo/lib/mock-api/mock-api.module.ts
+++ b/webapp/frontend/src/@treo/lib/mock-api/mock-api.module.ts
@@ -25,10 +25,11 @@ export class TreoMockApiModule
         return {
             ngModule : TreoMockApiModule,
             providers: [
+                ...mockDataServices,
                 {
                     provide   : APP_INITIALIZER,
-                    deps      : mockDataServices,
-                    useFactory: () => () => null,
+                    deps      :mockDataServices,
+                    useFactory: (...services) => () => {},
                     multi     : true
                 },
             ]

--- a/webapp/frontend/src/app/app.module.ts
+++ b/webapp/frontend/src/app/app.module.ts
@@ -13,6 +13,7 @@ import {mockDataServices} from 'app/data/mock';
 import {LayoutModule} from 'app/layout/layout.module';
 import {AppComponent} from 'app/app.component';
 import {appRoutes, getAppBaseHref} from 'app/app.routing';
+import {environment} from '../environments/environment';
 
 const routerConfig: ExtraOptions = {
     scrollPositionRestoration: 'enabled',
@@ -25,7 +26,7 @@ let dev = [
 
 // if production clear dev imports and set to prod mode
 // @ts-ignore
-if (process.env.NODE_ENV === 'production') {
+if (environment.production) {
     dev = [];
     enableProdMode();
 }

--- a/webapp/frontend/src/app/data/mock/index.ts
+++ b/webapp/frontend/src/app/data/mock/index.ts
@@ -1,7 +1,9 @@
 import { SummaryMockApi } from 'app/data/mock/summary';
 import { DetailsMockApi } from 'app/data/mock/device/details';
+import { SettingsMockApi } from 'app/data/mock/settings';
 
 export const mockDataServices = [
     SummaryMockApi,
     DetailsMockApi,
+    SettingsMockApi,
 ];

--- a/webapp/frontend/src/app/data/mock/settings/data.ts
+++ b/webapp/frontend/src/app/data/mock/settings/data.ts
@@ -1,0 +1,18 @@
+export const settings = {
+  settings: {
+      theme: 'light',
+      layout: 'material',
+      dashboard_display: 'name',
+      dashboard_sort: 'status',
+      temperature_unit: 'celsius',
+      file_size_si_units: false,
+      powered_on_hours_unit: 'humanize',
+      line_stroke: 'smooth',
+      metrics: {
+          notify_level: 2,
+          status_filter_attributes: 0,
+          status_threshold: 3,
+          repeat_notifications: true,
+      },
+  },
+};

--- a/webapp/frontend/src/app/data/mock/settings/index.ts
+++ b/webapp/frontend/src/app/data/mock/settings/index.ts
@@ -1,0 +1,29 @@
+import * as _ from 'lodash';
+
+import { Injectable } from '@angular/core';
+import { TreoMockApi } from '@treo/lib/mock-api/mock-api.interfaces';
+import { TreoMockApiService } from '@treo/lib/mock-api/mock-api.service';
+import { settings as settingsData } from 'app/data/mock/settings/data';
+
+@Injectable({
+    providedIn: 'root'
+})
+export class SettingsMockApi implements TreoMockApi
+{
+    private _settings: any;
+
+    constructor(private _treoMockApiService: TreoMockApiService)
+    {
+        this._settings = settingsData;
+        this.register();
+    }
+
+    register(): void
+    {
+        this._treoMockApiService.onGet('/api/settings')
+            .reply(() => [200, _.cloneDeep(this._settings)]);
+
+        this._treoMockApiService.onPost('/api/settings')
+            .reply(() => [200, { success: true }]);
+    }
+}


### PR DESCRIPTION
CONTRIBUTING.md says that the front-end should be able to run standalone with mocked data.
```md
# Modifying the Scrutiny Frontend Angular SPA

The frontend is written in Angular. If you're working on the frontend and can use mocked data rather than a real backend, you can follow the instructions below:

1. install [NodeJS](https://nodejs.org/en/download/)
2. start the Angular Frontend Application
    ```bash
    cd webapp/frontend
    npm install
    npm run start -- --serve-path="/web/" --port 4200
    ```
3. open your browser and visit [http://localhost:4200/web](http://localhost:4200/web)
```

This was failing with a infinite loading screen.
<img width="3342" height="1755" alt="Screenshot 2025-12-14 at 12 28 14 AM" src="https://github.com/user-attachments/assets/6f35308c-d5bb-4495-abf4-faa8526452ab" />


This PR fixes this demo mode and the page now loads properly.
<img width="3355" height="1771" alt="Screenshot 2025-12-14 at 12 23 43 AM" src="https://github.com/user-attachments/assets/dae5a349-0b29-4f1a-b7e3-55cc7e67dd23" />


It adds a new mock API for `/api/settings` and fixes two configuration issues.
- The URL interceptor was getting confused with the redirect from `/web` to `/web/dashboard`
- The code to check if the SPA was running now uses the "angular" way of checking the environment.