### PR TITLE
Human-readable values for data written/read attributes

### DIFF
--- a/webapp/frontend/src/app/data/mock/device/details/sdb.ts
+++ b/webapp/frontend/src/app/data/mock/device/details/sdb.ts
@@ -30,6 +30,17 @@ export const sdb = {
             'power_on_hours': 1730,
             'power_cycle_count': 9,
             'attrs': {
+                '241': {
+                    'attribute_id': 241,
+                    'value': 100,
+                    'thresh': 0,
+                    'worst': 100,
+                    'raw_value': 1953125000,
+                    'raw_string': '1953125000',
+                    'when_failed': '',
+                    'transformed_value': 0,
+                    'status': 0
+                },
                 '1': {
                     'attribute_id': 1,
                     'value': 100,
@@ -456,6 +467,17 @@ export const sdb = {
                     'worst': 100,
                     'raw_value': 1730,
                     'raw_string': '1730',
+                    'when_failed': '',
+                    'transformed_value': 0,
+                    'status': 0
+                },
+                '241': {
+                    'attribute_id': 241,
+                    'value': 100,
+                    'thresh': 0,
+                    'worst': 100,
+                    'raw_value': 1953125000,
+                    'raw_string': '1953125000',
                     'when_failed': '',
                     'transformed_value': 0,
                     'status': 0

--- a/webapp/frontend/src/app/modules/detail/detail.component.ts
+++ b/webapp/frontend/src/app/modules/detail/detail.component.ts
@@ -17,6 +17,7 @@ import {SmartModel} from 'app/core/models/measurements/smart-model';
 import {SmartAttributeModel} from 'app/core/models/measurements/smart-attribute-model';
 import {AttributeMetadataModel} from 'app/core/models/thresholds/attribute-metadata-model';
 import {DeviceStatusPipe} from 'app/shared/device-status.pipe';
+import {FileSizePipe} from 'app/shared/file-size.pipe';
 
 // from Constants.go - these must match
 const AttributeStatusPassed = 0
@@ -204,8 +205,12 @@ export class DetailComponent implements OnInit, AfterViewInit, OnDestroy {
         }
     }
 
-    getAttributeValue(attributeData: SmartAttributeModel): number {
+    getAttributeValue(attributeData: SmartAttributeModel): number | string {
         if (this.isAta()) {
+            if (attributeData.attribute_id === 241 || attributeData.attribute_id === 242) {
+                return `${attributeData.raw_value} [${new FileSizePipe().transform(attributeData.raw_value * 512, this.config?.file_size_si_units)}]`
+            }
+
             const attributeMetadata = this.metadata[attributeData.attribute_id]
             if (!attributeMetadata) {
                 return attributeData.value
@@ -216,6 +221,8 @@ export class DetailComponent implements OnInit, AfterViewInit, OnDestroy {
             } else {
                 return attributeData.value
             }
+        } else if (this.isNvme() && (attributeData.attribute_id === 'data_units_written' || attributeData.attribute_id === 'data_units_read')) {
+            return `${attributeData.value} [${new FileSizePipe().transform(attributeData.value * 1000 * 512, this.config?.file_size_si_units)}]`
         } else {
             return attributeData.value
         }


### PR DESCRIPTION
This small PR adds a human-readable data size in brackets next to the SMART attributes related to data written/read. This makes it a bit easier to understand the amount of data written/read on a drive and mirrors the format `smartctl` uses in their reporting as well.

**Before:**
<img width="580" height="117" alt="image" src="https://github.com/user-attachments/assets/eabc3866-cbf9-4b98-9ba9-a9c595370e3f" />

**After:**
<img width="562" height="145" alt="image" src="https://github.com/user-attachments/assets/1fb25405-8f0f-4f54-865e-d6bee1959cbc" />

---

## AI Summary:
> This pull request enhances the display of SMART attribute values in the device details view by improving how certain storage-related attributes are formatted and shown to users. It introduces human-readable file size formatting for specific ATA and NVMe attributes, and updates the mock device data to include attribute 241 in two places.
> 
> **Frontend Enhancements:**
> 
> * Updated the `getAttributeValue` method in `detail.component.ts` to display ATA attributes 241 and 242 as both their raw value and a formatted file size using `FileSizePipe`.
> * Enhanced the `getAttributeValue` method to display NVMe attributes `data_units_written` and `data_units_read` as both their value and a formatted file size.
> * Imported `FileSizePipe` in `detail.component.ts` to support the new formatting logic.
> 
> **Mock Data Updates:**
> 
> * Added attribute 241 to the `attrs` object in two places within the `sdb` mock device data to ensure consistency with the new display logic. [[1]](diffhunk://#diff-8b3d2b3eeb5001c8c9a0dff843c81652062ccca3407e74a6668e4030cc3b54f7R33-R43) [[2]](diffhunk://#diff-8b3d2b3eeb5001c8c9a0dff843c81652062ccca3407e74a6668e4030cc3b54f7R473-R483)