### PR TITLE
Friendly Name

### DIFF
--- a/webapp/backend/pkg/database/scrutiny_repository_device.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_device.go
@@ -74,6 +74,7 @@ func (sr *scrutinyRepository) UpdateDeviceStatus(ctx context.Context, scrutiny_u
 	}
 
 	device.DeviceStatus = pkg.DeviceStatusSet(device.DeviceStatus, status)
+	device.FriendlyName = sr.GetDeviceFriendlyName(device.ScrutinyUUID)
 	return device, sr.gormClient.Model(&device).Updates(device).Error
 }
 

--- a/webapp/backend/pkg/database/scrutiny_repository_device.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_device.go
@@ -18,6 +18,12 @@ import (
 // Device
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+func (sr *scrutinyRepository) GetDeviceFriendlyName(scrutiny_uuid uuid.UUID) string {
+	var envuuid = strings.Replace(scrutiny_uuid.String(), "-", "_", -1)
+	var env = "FRIENDLY_NAME_" + envuuid
+	return os.Getenv(env)
+}
+
 // insert device into DB (and update specified columns if device is already registered)
 // update device fields that may change: (DeviceType, HostID)
 func (sr *scrutinyRepository) RegisterDevice(ctx context.Context, dev models.Device) error {
@@ -39,9 +45,7 @@ func (sr *scrutinyRepository) GetDevices(ctx context.Context) ([]models.Device, 
 	}
 
 	for i := range devices {
-		var envuuid = strings.Replace(devices[i].ScrutinyUUID.String(), "-", "_", -1)
-		var env = "FRIENDLY_NAME_" + envuuid
-		devices[i].FriendlyName = os.Getenv(env)
+		devices[i].FriendlyName = sr.GetDeviceFriendlyName(devices[i].ScrutinyUUID)
 	}
 
 	return devices, nil
@@ -82,7 +86,7 @@ func (sr *scrutinyRepository) GetDeviceDetails(ctx context.Context, scrutiny_uui
 		return models.Device{}, err
 	}
 
-	device.FriendlyName = os.Getenv("FRIENDLY_NAME_" + device.ScrutinyUUID.String())
+	device.FriendlyName = sr.GetDeviceFriendlyName(device.ScrutinyUUID)
 	return device, nil
 }
 

--- a/webapp/backend/pkg/database/scrutiny_repository_device.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_device.go
@@ -3,6 +3,8 @@ package database
 import (
 	"context"
 	"fmt"
+	"os"
+	"strings"
 	"time"
 
 	"github.com/analogj/scrutiny/webapp/backend/pkg"
@@ -35,6 +37,13 @@ func (sr *scrutinyRepository) GetDevices(ctx context.Context) ([]models.Device, 
 	if err := sr.gormClient.WithContext(ctx).Find(&devices).Error; err != nil {
 		return nil, fmt.Errorf("could not get device summary from DB: %v", err)
 	}
+
+	for i := range devices {
+		var envuuid = strings.Replace(devices[i].ScrutinyUUID.String(), "-", "_", -1)
+		var env = "FRIENDLY_NAME_" + envuuid
+		devices[i].FriendlyName = os.Getenv(env)
+	}
+
 	return devices, nil
 }
 
@@ -73,6 +82,7 @@ func (sr *scrutinyRepository) GetDeviceDetails(ctx context.Context, scrutiny_uui
 		return models.Device{}, err
 	}
 
+	device.FriendlyName = os.Getenv("FRIENDLY_NAME_" + device.ScrutinyUUID.String())
 	return device, nil
 }
 

--- a/webapp/backend/pkg/models/device.go
+++ b/webapp/backend/pkg/models/device.go
@@ -27,6 +27,7 @@ type Device struct {
 	DeviceUUID     string `json:"device_uuid"`
 	DeviceSerialID string `json:"device_serial_id"`
 	DeviceLabel    string `json:"device_label"`
+	FriendlyName   string `json:"friendly_name"`
 
 	Manufacturer   string `json:"manufacturer"`
 	ModelName      string `json:"model_name"`

--- a/webapp/backend/pkg/notify/notify.go
+++ b/webapp/backend/pkg/notify/notify.go
@@ -20,9 +20,9 @@ import (
 	"github.com/analogj/scrutiny/webapp/backend/pkg/models/measurements"
 	"github.com/analogj/scrutiny/webapp/backend/pkg/thresholds"
 	"github.com/gin-gonic/gin"
+	"github.com/gofrs/uuid/v5"
 	"github.com/nicholas-fedor/shoutrrr"
 	shoutrrrTypes "github.com/nicholas-fedor/shoutrrr/pkg/types"
-	"github.com/gofrs/uuid/v5"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
 )
@@ -127,6 +127,7 @@ type Payload struct {
 	HostId       string `json:"host_id,omitempty"` //host id (optional)
 	DeviceType   string `json:"device_type"`       //ATA/SCSI/NVMe
 	DeviceName   string `json:"device_name"`       //dev/sda
+	FriendlyName string `json:"friendly_name"`     //dev/sda
 	DeviceSerial string `json:"device_serial"`     //WDDJ324KSO
 	Test         bool   `json:"test"`              // false
 
@@ -142,6 +143,7 @@ func NewPayload(device models.Device, test bool, currentTime ...time.Time) Paylo
 		HostId:       strings.TrimSpace(device.HostId),
 		DeviceType:   device.DeviceType,
 		DeviceName:   device.DeviceName,
+		FriendlyName: device.FriendlyName,
 		DeviceSerial: device.SerialNumber,
 		Test:         test,
 	}
@@ -194,6 +196,10 @@ func (p *Payload) GenerateMessage() string {
 	messageParts = append(messageParts, fmt.Sprintf("Scrutiny SMART error notification for device: %s", p.DeviceName))
 	if len(p.HostId) > 0 {
 		messageParts = append(messageParts, fmt.Sprintf("Host Id: %s", p.HostId))
+	}
+
+	if len(p.FriendlyName) > 0 {
+		messageParts = append(messageParts, fmt.Sprintf("Name: %s", p.FriendlyName))
 	}
 
 	messageParts = append(messageParts,

--- a/webapp/backend/pkg/web/handler/send_test_notification.go
+++ b/webapp/backend/pkg/web/handler/send_test_notification.go
@@ -1,13 +1,14 @@
 package handler
 
 import (
+	"net/http"
+
 	"github.com/analogj/scrutiny/webapp/backend/pkg"
 	"github.com/analogj/scrutiny/webapp/backend/pkg/config"
 	"github.com/analogj/scrutiny/webapp/backend/pkg/models"
 	"github.com/analogj/scrutiny/webapp/backend/pkg/notify"
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
-	"net/http"
 )
 
 // Send test notification
@@ -22,6 +23,7 @@ func SendTestNotification(c *gin.Context) {
 			SerialNumber: "FAKEWDDJ324KSO",
 			DeviceType:   pkg.DeviceProtocolAta,
 			DeviceName:   "/dev/sda",
+			FriendlyName: "My Device",
 		},
 		true,
 	)

--- a/webapp/frontend/src/app/core/config/app.config.ts
+++ b/webapp/frontend/src/app/core/config/app.config.ts
@@ -4,7 +4,7 @@ import {Layout} from 'app/layout/layout.types';
 export type Theme = 'light' | 'dark' | 'system';
 
 // Device title to display on the dashboard
-export type DashboardDisplay = 'name' | 'serial_id' | 'uuid' | 'label'
+export type DashboardDisplay = 'name' | 'serial_id' | 'uuid' | 'label' | 'friendly_name'
 
 export type DashboardSort = 'status' | 'title' | 'age'
 
@@ -54,7 +54,7 @@ export interface AppConfig {
     line_stroke?: LineStroke;
 
     // Settings from Scrutiny API
-    
+
     collector?: {
         discard_sct_temp_history?: boolean
     }
@@ -80,7 +80,7 @@ export const appConfig: AppConfig = {
     theme: 'light',
     layout: 'material',
 
-    dashboard_display: 'name',
+    dashboard_display: 'friendly_name',
     dashboard_sort: 'status',
 
     temperature_unit: 'celsius',
@@ -88,7 +88,7 @@ export const appConfig: AppConfig = {
     powered_on_hours_unit: 'humanize',
 
     line_stroke: 'smooth',
-    
+
     collector: {
         discard_sct_temp_history : false,
     },

--- a/webapp/frontend/src/app/core/models/device-model.ts
+++ b/webapp/frontend/src/app/core/models/device-model.ts
@@ -7,6 +7,7 @@ export interface DeviceModel {
     device_uuid?: string;
     device_serial_id?: string;
     device_label?: string;
+    friendly_name?: string;
 
     manufacturer: string;
     model_name: string;

--- a/webapp/frontend/src/app/layout/common/dashboard-settings/dashboard-settings.component.html
+++ b/webapp/frontend/src/app/layout/common/dashboard-settings/dashboard-settings.component.html
@@ -22,6 +22,7 @@
                     <mat-option value="serial_id">Serial ID</mat-option>
                     <mat-option value="uuid">UUID</mat-option>
                     <mat-option value="label">Label</mat-option>
+                    <mat-option value="friendly_name">Friendly Name</mat-option>
                 </mat-select>
             </mat-form-field>
 

--- a/webapp/frontend/src/app/modules/detail/detail.component.html
+++ b/webapp/frontend/src/app/modules/detail/detail.component.html
@@ -68,6 +68,16 @@
                         <div class="text-secondary text-md">Status</div>
                     </div>
 
+                    <div *ngIf="device?.friendly_name" class="my-2 col-span-2 lt-md:col-span-1">
+                        <div>{{device?.friendly_name}}</div>
+                        <div class="text-secondary text-md">Friendly Name</div>
+                    </div>
+
+                    <div *ngIf="device?.friendly_name" class="my-2 col-span-2 lt-md:col-span-1">
+                        <div>/dev/{{device?.device_name}}</div>
+                        <div class="text-secondary text-md">Name</div>
+                    </div>
+
                     <div *ngIf="device?.host_id" class="my-2 col-span-2 lt-md:col-span-1">
                         <div>{{device?.host_id}}</div>
                         <div class="text-secondary text-md">Host ID</div>

--- a/webapp/frontend/src/app/shared/device-title.pipe.ts
+++ b/webapp/frontend/src/app/shared/device-title.pipe.ts
@@ -26,10 +26,8 @@ export class DeviceTitlePipe implements PipeTransform {
                 break;
             case 'friendly_name':
                 if(device.friendly_name !== ''){
-                    console.log("fn")
                     titleParts.push(device.friendly_name)
                 } else {
-                    console.log("fb")
                     titleParts.push(`/dev/${device.device_name}`)
                 }
                 break;

--- a/webapp/frontend/src/app/shared/device-title.pipe.ts
+++ b/webapp/frontend/src/app/shared/device-title.pipe.ts
@@ -9,14 +9,6 @@ export class DeviceTitlePipe implements PipeTransform {
     static deviceTitleForType(device: DeviceModel, titleType: string): string {
         const titleParts = []
         switch(titleType){
-            case 'name':
-                titleParts.push(`/dev/${device.device_name}`)
-                if (device.device_type && device.device_type !== 'scsi' && device.device_type !== 'ata'){
-                    titleParts.push(device.device_type)
-                }
-                titleParts.push(device.model_name)
-
-                break;
             case 'serial_id':
                 if(!device.device_serial_id) return ''
                 titleParts.push(`/by-id/${device.device_serial_id}`)
@@ -31,6 +23,22 @@ export class DeviceTitlePipe implements PipeTransform {
                 } else if(device.device_label){
                     titleParts.push(`/by-label/${device.device_label}`)
                 }
+                break;
+            case 'friendly_name':
+                if(device.friendly_name !== ''){
+                    console.log("fn")
+                    titleParts.push(device.friendly_name)
+                } else {
+                    console.log("fb")
+                    titleParts.push(`/dev/${device.device_name}`)
+                }
+                break;
+            default:
+                titleParts.push(`/dev/${device.device_name}`)
+                if (device.device_type && device.device_type !== 'scsi' && device.device_type !== 'ata'){
+                    titleParts.push(device.device_type)
+                }
+                titleParts.push(device.model_name)
                 break;
         }
         return titleParts.join(' - ')


### PR DESCRIPTION
Closes #926

First working draft on friendly names.

The names are provided via ENV:
`export FRIENDLY_NAME_123_456_abc_def_12ab=Rivendell`
this corresponds to deviceUUID, except all dashes are now underscores to make it work with the env.

The ui shows either the friendly name, or the device name as a fallback.
