### PR TITLE
Install git from default repo in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,8 +35,7 @@ jobs:
     steps:
       - name: Git
         run: |
-          apt-get update && apt-get install -y software-properties-common
-          add-apt-repository ppa:git-core/ppa && apt-get update && apt-get install -y git
+          apt-get update && apt-get install -y git
           git --version
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
Debian 13 removed software-properties-common which was used to add-apt-repository. The version of git in the Debian repo should be modern enough as is.