### PR TITLE
Fix fallback WWN in UUID migration to avoid ghost disks

### DIFF
--- a/collector/pkg/collector/metrics.go
+++ b/collector/pkg/collector/metrics.go
@@ -69,12 +69,15 @@ func (mc *MetricsCollector) Run() error {
 	for _, device := range rawDetectedStorageDevices {
 		if device.ScrutinyUUID.IsNil() {
 			mc.logger.Errorf("Device %s has no scrutiny UUID; skipping (no data association possible).", device.DeviceName)
+			mc.logger.Debugf("Raw detected device: model=%q serial=%q wwn=%q ScrutinyUUID=%s",
+				device.ModelName, device.SerialNumber, device.WWN, device.ScrutinyUUID)
 			continue
 		}
 		detectedStorageDevices = append(detectedStorageDevices, device)
 	}
 
-	mc.logger.Infoln("Sending detected devices to API, for filtering & validation")
+	mc.logger.Infof("Sending %d/%d detected devices to API for filtering & validation",
+		len(detectedStorageDevices), len(rawDetectedStorageDevices))
 	jsonObj, _ := json.Marshal(detectedStorageDevices)
 	mc.logger.Debugf("Detected devices: %v", string(jsonObj))
 	err = mc.postJson(apiEndpoint.String(), models.DeviceWrapper{

--- a/collector/pkg/detect/detect.go
+++ b/collector/pkg/detect/detect.go
@@ -106,6 +106,8 @@ func (d *Detect) SmartCtlInfo(device *models.Device) error {
 	}
 
 	device.ScrutinyUUID = GenerateScrutinyUUID(device.ModelName, device.SerialNumber, device.WWN)
+	d.Logger.Debugf("Generated ScrutinyUUID (Model='%s', Serial='%s', WWN='%s'): %s",
+		device.ModelName, device.SerialNumber, device.WWN, device.ScrutinyUUID)
 
 	return nil
 }

--- a/webapp/backend/pkg/database/scrutiny_repository_migrations.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_migrations.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/analogj/scrutiny/collector/pkg/detect"
@@ -429,6 +430,7 @@ func (sr *scrutinyRepository) Migrate(ctx context.Context) error {
 		{
 			ID: "m20260216155600", // add ScrutinyUUID as primary key
 			Migrate: func(tx *gorm.DB) error {
+				wwnToUUID := make(map[string]string)
 				devices := []m20260216155600.Device{}
 				if err := tx.Find(&devices).Error; err != nil {
 					return err
@@ -436,7 +438,23 @@ func (sr *scrutinyRepository) Migrate(ctx context.Context) error {
 				sr.logger.Debug("Generating Scrutiny UUIDs")
 				for i := range devices {
 					device := &devices[i]
-					device.ScrutinyUUID = detect.GenerateScrutinyUUID(device.ModelName, device.SerialNumber, device.WWN)
+					newWWN := device.WWN
+
+					// Fix disks with old serial-based fallback WWN so UUID will be accurate.
+					if len(device.WWN) > 0 && device.WWN == strings.ToLower(device.SerialNumber) {
+						newWWN = ""
+					}
+
+					// Generate UUID with temporary WWN
+					device.ScrutinyUUID = detect.GenerateScrutinyUUID(device.ModelName, device.SerialNumber, newWWN)
+
+					// Add UUID to map with old WWN before we lose it
+					wwnToUUID[device.WWN] = device.ScrutinyUUID.String()
+
+					// Finally reset old fallback WWNs
+					if len(newWWN) == 0 {
+						device.WWN = ""
+					}
 				}
 
 				// sqlite doesn't support altering columns
@@ -459,12 +477,7 @@ func (sr *scrutinyRepository) Migrate(ctx context.Context) error {
 					return err
 				}
 
-				//
-				wwnToUUID := make(map[string]string)
-				for _, device := range devices {
-					wwnToUUID[device.WWN] = device.ScrutinyUUID.String()
-				}
-
+				// Migrate WWN -> UUID in influxdb
 				err := m20260216155600_ChangeInfluxDBTags(sr, ctx, wwnToUUID)
 				if ignorePastRetentionPolicyError(err) != nil {
 					return err


### PR DESCRIPTION
Resolves an issue discussed in #994 where a change to fallback WWN at the same time as migrating to UUIDs caused a mismatch for no-wwn disks.

@kaysond I *think* this should do it? Added a length check before it resets WWN to be *extra* safe in case a disk had no wwn OR serial (although that "should" never happen).

Influx migration relies on the old WWN so I had to shift things around a bit, but originally I had it running a `.Model()`query (something like `.Where("scrutiny_uuid IN ?", clearlist).Update("wwn", "")`) *after* the influx migration. Ended up just moving the map assignment further up, then we can avoid the extra update entirely.

Obviously I'd still prefer to do it in a new migration instead so everyone could benefit, but this should at least prevent it becoming an issue for anyone that *didn't* update yet.

**Note:** I've read through it 50 times trying to think of anything it might break, but *I **haven't tested** it at all* other than to make sure **it builds**. You'll want to run some sanity checks :smile: 