### PR TITLE
docs: document collector device allow list

### DIFF
--- a/docs/TROUBLESHOOTING_DEVICE_COLLECTOR.md
+++ b/docs/TROUBLESHOOTING_DEVICE_COLLECTOR.md
@@ -73,6 +73,16 @@ Scrutiny will supports overriding the detected device type via the config file.
 
 [example.collector.yaml](https://github.com/AnalogJ/scrutiny/blob/master/example.collector.yaml)
 
+To restrict collection to only specific devices, set `allow_listed_devices` to
+the full device paths reported by `smartctl --scan`. If this setting is omitted
+or empty, Scrutiny collects every detected device.
+
+```yaml
+allow_listed_devices:
+  - /dev/sda
+  - /dev/sdb
+```
+
 ### RAID Controllers (Megaraid/3ware/HBA/Adaptec/HPE/etc)
 Smartctl has support for a large number of [RAID controllers](https://www.smartmontools.org/wiki/Supported_RAID-Controllers), however this 
 support is not automatic, and may require some additional device type hinting. You can provide this information to the Scrutiny collector

--- a/example.collector.yaml
+++ b/example.collector.yaml
@@ -65,6 +65,13 @@ devices:
 #      metrics_smart_args: '--xall --json -T permissive' # used to retrieve smart data for each device.
 
 
+# To collect metrics for only specific devices from `smartctl --scan`, list their
+# device paths here. When omitted or empty, Scrutiny collects every detected device.
+#allow_listed_devices:
+#  - /dev/sda
+#  - /dev/sdb
+
+
 #log:
 #  file: '' #absolute or relative paths allowed, eg. web.log
 #  level: INFO


### PR DESCRIPTION
## Summary
- add `allow_listed_devices` to `example.collector.yaml`
- document the same setting in the collector troubleshooting guide
- clarify that an omitted or empty allow list keeps collecting every detected device

## Verification
- `ruby -e 'require "yaml"; YAML.load_file("example.collector.yaml"); puts "yaml ok"'`
- `go test ./collector/pkg/config -run TestConfiguration_DeviceAllowList -count=1`
- `git diff --check`

## AI assistance
OpenAI Codex helped inspect the existing allow-list implementation/tests and draft this docs-only change. I reviewed the diff and verified it with the commands above.

Closes #997
