### PR TITLE
Fix smart support detection

### DIFF
--- a/collector/pkg/detect/detect.go
+++ b/collector/pkg/detect/detect.go
@@ -84,6 +84,7 @@ func (d *Detect) SmartCtlInfo(device *models.Device) error {
 	device.RotationSpeed = availableDeviceInfo.RotationRate
 	device.Capacity = availableDeviceInfo.Capacity()
 	device.FormFactor = availableDeviceInfo.FormFactor.Name
+	device.SmartSupport = availableDeviceInfo.SmartSupport.Supported()
 	device.DeviceType = availableDeviceInfo.Device.Type
 	device.DeviceProtocol = availableDeviceInfo.Device.Protocol
 	if len(availableDeviceInfo.Vendor) > 0 {

--- a/collector/pkg/detect/detect_test.go
+++ b/collector/pkg/detect/detect_test.go
@@ -357,9 +357,11 @@ func TestDetect_SmartCtlInfo(t *testing.T) {
 			someCapacity       int64 = 3840755982336
 		)
 
+		fullDeviceName := detect.DevicePrefix() + someDeviceName
+
 		fakeConfig := mock_config.NewMockInterface(ctrl)
 		fakeConfig.EXPECT().
-			GetCommandMetricsInfoArgs("/dev/" + someDeviceName).
+			GetCommandMetricsInfoArgs(fullDeviceName).
 			Return(someArgs)
 		fakeConfig.EXPECT().
 			GetString("commands.metrics_smartctl_bin").
@@ -372,7 +374,7 @@ func TestDetect_SmartCtlInfo(t *testing.T) {
 
 		fakeShell := mock_shell.NewMockInterface(ctrl)
 		fakeShell.EXPECT().
-			Command(someLogger, "smartctl", append(strings.Split(someArgs, " "), "/dev/"+someDeviceName), "", gomock.Any()).
+			Command(someLogger, "smartctl", append(strings.Split(someArgs, " "), fullDeviceName), "", gomock.Any()).
 			Return(string(smartctlInfoResults), err)
 
 		d := detect.Detect{
@@ -397,71 +399,60 @@ func TestDetect_SmartCtlInfo(t *testing.T) {
 		assert.Equal(t, someCapacity, someDevice.Capacity)
 	})
 
-	t.Run("should report smart support from object", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
+	for _, tt := range []struct {
+		name     string
+		filename string
+	}{
+		{
+			name:     "should report smart support from legacy boolean",
+			filename: "smartctl_info_sata_smart_support_bool.json",
+		},
+		{
+			name:     "should report smart support from object",
+			filename: "smartctl_info_sata_smart_support_object.json",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
 
-		const (
-			someArgs       = "--info --json"
-			someDeviceName = "sata1"
-		)
+			const (
+				someArgs       = "--info --json"
+				someDeviceName = "sata1"
+			)
 
-		fakeConfig := mock_config.NewMockInterface(ctrl)
-		fakeConfig.EXPECT().
-			GetCommandMetricsInfoArgs("/dev/" + someDeviceName).
-			Return(someArgs)
-		fakeConfig.EXPECT().
-			GetString("commands.metrics_smartctl_bin").
-			Return("smartctl")
+			fullDeviceName := detect.DevicePrefix() + someDeviceName
 
-		someLogger := logrus.WithFields(logrus.Fields{})
+			fakeConfig := mock_config.NewMockInterface(ctrl)
+			fakeConfig.EXPECT().
+				GetCommandMetricsInfoArgs(fullDeviceName).
+				Return(someArgs)
+			fakeConfig.EXPECT().
+				GetString("commands.metrics_smartctl_bin").
+				Return("smartctl")
 
-		smartctlInfoResults := `{
-			"device": {
-				"name": "/dev/sata1",
-				"info_name": "/dev/sata1 [SAT]",
-				"type": "sat",
-				"protocol": "ATA"
-			},
-			"model_name": "WD Red SA500 2.5 4TB",
-			"serial_number": "2433274A1T13",
-			"firmware_version": "540400WD",
-			"user_capacity": {
-				"blocks": 7814037168,
-				"bytes": 4000787030016
-			},
-			"interface_speed": {
-				"current": {
-					"string": "6.0 Gb/s"
-				}
-			},
-			"wwn": {
-				"naa": 5,
-				"oui": 6980,
-				"id": 19953498261
-			},
-			"smart_support": {
-				"available": true,
-				"enabled": true
+			someLogger := logrus.WithFields(logrus.Fields{})
+
+			smartctlInfoResults, err := os.ReadFile("testdata/" + tt.filename)
+			require.NoError(t, err)
+
+			fakeShell := mock_shell.NewMockInterface(ctrl)
+			fakeShell.EXPECT().
+				Command(someLogger, "smartctl", append(strings.Split(someArgs, " "), fullDeviceName), "", gomock.Any()).
+				Return(string(smartctlInfoResults), nil)
+
+			d := detect.Detect{
+				Logger: someLogger,
+				Shell:  fakeShell,
+				Config: fakeConfig,
 			}
-		}`
 
-		fakeShell := mock_shell.NewMockInterface(ctrl)
-		fakeShell.EXPECT().
-			Command(someLogger, "smartctl", append(strings.Split(someArgs, " "), "/dev/"+someDeviceName), "", gomock.Any()).
-			Return(smartctlInfoResults, nil)
+			someDevice := &models.Device{
+				DeviceName: someDeviceName,
+			}
 
-		d := detect.Detect{
-			Logger: someLogger,
-			Shell:  fakeShell,
-			Config: fakeConfig,
-		}
+			require.NoError(t, d.SmartCtlInfo(someDevice))
 
-		someDevice := &models.Device{
-			DeviceName: someDeviceName,
-		}
-
-		require.NoError(t, d.SmartCtlInfo(someDevice))
-
-		assert.True(t, someDevice.SmartSupport)
-	})
+			assert.True(t, someDevice.SmartSupport)
+		})
+	}
 }

--- a/collector/pkg/detect/detect_test.go
+++ b/collector/pkg/detect/detect_test.go
@@ -396,4 +396,72 @@ func TestDetect_SmartCtlInfo(t *testing.T) {
 		assert.Equal(t, someDeviceType, someDevice.DeviceType)
 		assert.Equal(t, someCapacity, someDevice.Capacity)
 	})
+
+	t.Run("should report smart support from object", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+
+		const (
+			someArgs       = "--info --json"
+			someDeviceName = "sata1"
+		)
+
+		fakeConfig := mock_config.NewMockInterface(ctrl)
+		fakeConfig.EXPECT().
+			GetCommandMetricsInfoArgs("/dev/" + someDeviceName).
+			Return(someArgs)
+		fakeConfig.EXPECT().
+			GetString("commands.metrics_smartctl_bin").
+			Return("smartctl")
+
+		someLogger := logrus.WithFields(logrus.Fields{})
+
+		smartctlInfoResults := `{
+			"device": {
+				"name": "/dev/sata1",
+				"info_name": "/dev/sata1 [SAT]",
+				"type": "sat",
+				"protocol": "ATA"
+			},
+			"model_name": "WD Red SA500 2.5 4TB",
+			"serial_number": "2433274A1T13",
+			"firmware_version": "540400WD",
+			"user_capacity": {
+				"blocks": 7814037168,
+				"bytes": 4000787030016
+			},
+			"interface_speed": {
+				"current": {
+					"string": "6.0 Gb/s"
+				}
+			},
+			"wwn": {
+				"naa": 5,
+				"oui": 6980,
+				"id": 19953498261
+			},
+			"smart_support": {
+				"available": true,
+				"enabled": true
+			}
+		}`
+
+		fakeShell := mock_shell.NewMockInterface(ctrl)
+		fakeShell.EXPECT().
+			Command(someLogger, "smartctl", append(strings.Split(someArgs, " "), "/dev/"+someDeviceName), "", gomock.Any()).
+			Return(smartctlInfoResults, nil)
+
+		d := detect.Detect{
+			Logger: someLogger,
+			Shell:  fakeShell,
+			Config: fakeConfig,
+		}
+
+		someDevice := &models.Device{
+			DeviceName: someDeviceName,
+		}
+
+		require.NoError(t, d.SmartCtlInfo(someDevice))
+
+		assert.True(t, someDevice.SmartSupport)
+	})
 }

--- a/collector/pkg/detect/testdata/smartctl_info_sata_smart_support_bool.json
+++ b/collector/pkg/detect/testdata/smartctl_info_sata_smart_support_bool.json
@@ -1,0 +1,26 @@
+{
+  "device": {
+    "name": "/dev/sata1",
+    "info_name": "/dev/sata1 [SAT]",
+    "type": "sat",
+    "protocol": "ATA"
+  },
+  "model_name": "WD Red SA500 2.5 4TB",
+  "serial_number": "2433274A1T13",
+  "firmware_version": "540400WD",
+  "user_capacity": {
+    "blocks": 7814037168,
+    "bytes": 4000787030016
+  },
+  "interface_speed": {
+    "current": {
+      "string": "6.0 Gb/s"
+    }
+  },
+  "wwn": {
+    "naa": 5,
+    "oui": 6980,
+    "id": 19953498261
+  },
+  "smart_support": true
+}

--- a/collector/pkg/detect/testdata/smartctl_info_sata_smart_support_object.json
+++ b/collector/pkg/detect/testdata/smartctl_info_sata_smart_support_object.json
@@ -1,0 +1,29 @@
+{
+  "device": {
+    "name": "/dev/sata1",
+    "info_name": "/dev/sata1 [SAT]",
+    "type": "sat",
+    "protocol": "ATA"
+  },
+  "model_name": "WD Red SA500 2.5 4TB",
+  "serial_number": "2433274A1T13",
+  "firmware_version": "540400WD",
+  "user_capacity": {
+    "blocks": 7814037168,
+    "bytes": 4000787030016
+  },
+  "interface_speed": {
+    "current": {
+      "string": "6.0 Gb/s"
+    }
+  },
+  "wwn": {
+    "naa": 5,
+    "oui": 6980,
+    "id": 19953498261
+  },
+  "smart_support": {
+    "available": true,
+    "enabled": true
+  }
+}

--- a/webapp/backend/pkg/models/collector/smart.go
+++ b/webapp/backend/pkg/models/collector/smart.go
@@ -1,5 +1,7 @@
 package collector
 
+import "encoding/json"
+
 type SmartInfo struct {
 	JSONFormatVersion []int `json:"json_format_version"`
 	Smartctl          struct {
@@ -67,6 +69,7 @@ type SmartInfo struct {
 	SmartStatus struct {
 		Passed bool `json:"passed"`
 	} `json:"smart_status"`
+	SmartSupport SmartSupport `json:"smart_support"`
 
 	PowerOnTime struct {
 		Hours int64 `json:"hours"`
@@ -239,6 +242,35 @@ type SmartInfo struct {
 	ScsiVersion         string              `json:"scsi_version"`
 	ScsiGrownDefectList int64               `json:"scsi_grown_defect_list"`
 	ScsiErrorCounterLog ScsiErrorCounterLog `json:"scsi_error_counter_log"`
+}
+
+type SmartSupport struct {
+	Available bool `json:"available"`
+	Enabled   bool `json:"enabled"`
+}
+
+func (s *SmartSupport) UnmarshalJSON(data []byte) error {
+	var supported bool
+	if err := json.Unmarshal(data, &supported); err == nil {
+		s.Available = supported
+		s.Enabled = supported
+		return nil
+	}
+
+	var support struct {
+		Available bool `json:"available"`
+		Enabled   bool `json:"enabled"`
+	}
+	if err := json.Unmarshal(data, &support); err != nil {
+		return err
+	}
+	s.Available = support.Available
+	s.Enabled = support.Enabled
+	return nil
+}
+
+func (s SmartSupport) Supported() bool {
+	return s.Available && s.Enabled
 }
 
 // Capacity finds the total capacity of the device in bytes, or 0 if unknown.

--- a/webapp/backend/pkg/models/collector/smart.go
+++ b/webapp/backend/pkg/models/collector/smart.go
@@ -250,8 +250,9 @@ type SmartSupport struct {
 }
 
 func (s *SmartSupport) UnmarshalJSON(data []byte) error {
-	// Older smartctl versions report smart_support as a boolean, while newer
-	// versions report separate available/enabled fields.
+	// smartctl changed smart_support from a legacy boolean to an object with
+	// separate available/enabled fields. Accept both shapes so collectors keep
+	// reporting support correctly across smartctl versions.
 	var supported bool
 	if err := json.Unmarshal(data, &supported); err == nil {
 		s.Available = supported

--- a/webapp/backend/pkg/models/collector/smart.go
+++ b/webapp/backend/pkg/models/collector/smart.go
@@ -250,6 +250,8 @@ type SmartSupport struct {
 }
 
 func (s *SmartSupport) UnmarshalJSON(data []byte) error {
+	// Older smartctl versions report smart_support as a boolean, while newer
+	// versions report separate available/enabled fields.
 	var supported bool
 	if err := json.Unmarshal(data, &supported); err == nil {
 		s.Available = supported

--- a/webapp/backend/pkg/models/collector/smart_test.go
+++ b/webapp/backend/pkg/models/collector/smart_test.go
@@ -1,9 +1,11 @@
 package collector
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSmartInfo_Capacity(t *testing.T) {
@@ -30,4 +32,57 @@ func TestSmartInfo_Capacity(t *testing.T) {
 		var smartInfo SmartInfo
 		assert.Zero(t, smartInfo.Capacity())
 	})
+}
+
+func TestSmartSupport_UnmarshalJSON(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		input     string
+		available bool
+		enabled   bool
+		supported bool
+	}{
+		{
+			name:      "should report legacy boolean support",
+			input:     `true`,
+			available: true,
+			enabled:   true,
+			supported: true,
+		},
+		{
+			name:      "should report legacy boolean unsupported",
+			input:     `false`,
+			available: false,
+			enabled:   false,
+			supported: false,
+		},
+		{
+			name:      "should report object support",
+			input:     `{"available":true,"enabled":true}`,
+			available: true,
+			enabled:   true,
+			supported: true,
+		},
+		{
+			name:      "should require available and enabled object fields",
+			input:     `{"available":true,"enabled":false}`,
+			available: true,
+			enabled:   false,
+			supported: false,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var support SmartSupport
+			require.NoError(t, json.Unmarshal([]byte(tt.input), &support))
+
+			assert.Equal(t, tt.available, support.Available)
+			assert.Equal(t, tt.enabled, support.Enabled)
+			assert.Equal(t, tt.supported, support.Supported())
+		})
+	}
+}
+
+func TestSmartSupport_UnmarshalJSONInvalid(t *testing.T) {
+	var support SmartSupport
+	require.Error(t, json.Unmarshal([]byte(`"unsupported"`), &support))
 }


### PR DESCRIPTION
## Summary

- Parse `smart_support` from smartctl metadata when it is reported as either a boolean or the newer `{ "available": ..., "enabled": ... }` object.
- Copy the parsed support value into the collector device registration payload.
- Add a regression test using the smartctl object shape from the linked discussion.

Fixes #1004

## Validation

Passed:

- `go test ./collector/pkg/detect -run 'TestDetect_SmartCtlInfo/should_report_smart_support_from_object' -count=1`
- `go test ./collector/pkg/detect ./webapp/backend/pkg/models/collector -count=1`
- `go test ./collector/... ./webapp/backend/pkg/models/... -count=1`
- `git diff --check`

Also ran `go test ./...`; all collector and backend model packages passed, but the full run failed in `webapp/backend/pkg/web` because local InfluxDB is not running on `localhost:8086`.

I also ran the repo lint command. The Makefile target first failed because `~/go/bin` was not on `PATH`; after running the installed linter directly, it reported existing repository-wide findings outside this change, including errcheck/staticcheck/gofmt issues in unrelated files. No lint findings were reported for the files touched here.

## AI usage

Tool used: OpenAI GPT-5.

AI assistance was used to trace the collector parsing path, draft the small code/test change, and prepare this PR text. The final diff was reviewed and validated with the commands above. The behavioral verification is at the smartctl JSON parsing level using the `smart_support` object shape from the accepted issue/discussion; no Synology-specific hardware behavior is changed here.

## Review follow-up validation

2026-05-21:

- `git diff --check`
- `go test ./collector/pkg/detect -run 'TestDetect_SmartCtlInfo' -count=1`
- `go test ./webapp/backend/pkg/models/collector -count=1`

A broader local Windows run of `go test ./collector/pkg/detect ./webapp/backend/pkg/models/collector -count=1` still fails in existing scan tests that expect names like `sda` while the current fixtures produce `/dev/sda`. The touched `SmartCtlInfo` path and backend collector model package passed.