### PR TITLE
Include manifest.json in frontend build assets

### DIFF
--- a/webapp/frontend/angular.json
+++ b/webapp/frontend/angular.json
@@ -24,8 +24,11 @@
                         "tsConfig": "tsconfig.app.json",
                         "aot": true,
                         "assets": [
-                            "src/favicon-16x16.png",
-                            "src/favicon-32x32.png",
+                            {
+                                "glob": "*.{png,ico,json,xml}",
+                                "input": "src",
+                                "output": "."
+                            },
                             "src/assets"
                         ],
                         "stylePreprocessorOptions": {
@@ -96,8 +99,11 @@
                         "tsConfig": "tsconfig.spec.json",
                         "karmaConfig": "karma.conf.js",
                         "assets": [
-                            "src/favicon-16x16.png",
-                            "src/favicon-32x32.png",
+                            {
+                                "glob": "*.{png,ico,json,xml}",
+                                "input": "src",
+                                "output": "."
+                            },
                             "src/assets"
                         ],
                         "stylePreprocessorOptions": {


### PR DESCRIPTION
## Summary
- copy root-level frontend static assets during Angular builds
- include manifest.json, browserconfig.xml, and the icon files linked from index.html in the generated dist output

Fixes #1008

## Testing
- `npm ci`
- `npm run build:prod -- --output-path=/Users/deepakkudi23/scrutiny-1008-tmp/dist`
- `test -f /Users/deepakkudi23/scrutiny-1008-tmp/dist/manifest.json`
- `node -e "JSON.parse(require('fs').readFileSync('/Users/deepakkudi23/scrutiny-1008-tmp/dist/manifest.json','utf8'))"`
- `npx ng test --watch=false --browsers=ChromeHeadless`
- `git diff --check`

Note: `make binary-frontend` was not usable on my macOS environment because the local GNU Make is 3.81, which does not honor this Makefile's `.ONESHELL`; I ran the equivalent frontend commands directly from `webapp/frontend`.

## AI usage disclosure
This pull request was prepared with assistance from OpenAI GPT-5. I reviewed the generated changes and verified the frontend build output and test suite locally.