### PR TITLE
fix(frontend): sort all columns on drive details page (closes #656)

### DIFF
--- a/webapp/frontend/src/app/modules/detail/detail.component.ts
+++ b/webapp/frontend/src/app/modules/detail/detail.component.ts
@@ -131,7 +131,46 @@ export class DetailComponent implements OnInit, AfterViewInit, OnDestroy {
      * After view init
      */
     ngAfterViewInit(): void {
-        // Make the data source sortable
+        // The matColumnDef ids in the template (id, name, ideal, failure, ...) don't
+        // line up with the field names on SmartAttributeModel (attribute_id,
+        // failure_rate, ...) and several visible columns are derived through
+        // getters that pull from `metadata`. MatSort's default accessor falls back
+        // to a plain `row[columnId]` lookup, which silently returns undefined for
+        // those columns and disables sorting for them. Closes #656.
+        this.smartAttributeDataSource.sortingDataAccessor = (
+            attribute: SmartAttributeModel,
+            sortHeaderId: string,
+        ): string | number => {
+            switch (sortHeaderId) {
+                case 'id':
+                    // attribute_id is typed `number | string`; coerce to number so
+                    // numeric IDs sort numerically rather than lexicographically.
+                    return Number(attribute.attribute_id);
+                case 'name':
+                    return this.getAttributeName(attribute);
+                case 'value':
+                    return this.getAttributeValue(attribute);
+                case 'worst': {
+                    const worst = this.getAttributeWorst(attribute);
+                    return typeof worst === 'number' ? worst : '';
+                }
+                case 'thresh': {
+                    const thresh = this.getAttributeThreshold(attribute);
+                    return typeof thresh === 'number' ? thresh : '';
+                }
+                case 'ideal':
+                    return this.getAttributeIdeal(attribute) ?? '';
+                case 'failure':
+                    return attribute.failure_rate ?? 0;
+                // `status` is read straight off the model (number); `history` is a
+                // sparkline with no meaningful scalar to sort against, but exposing
+                // the latest observed value still gives users a deterministic order.
+                case 'history':
+                    return this.getAttributeValue(attribute);
+                default:
+                    return (attribute as Record<string, any>)[sortHeaderId];
+            }
+        };
         this.smartAttributeDataSource.sort = this.smartAttributeTableMatSort;
     }
 


### PR DESCRIPTION
## Summary

Closes #656.

Clicking any column header other than **Status**, **Value**, or **Threshold** on the drive details SMART attributes table re-renders the rows in the same order with no error. The `mat-sort-header` directive is set on every column, but `MatTableDataSource`'s default `sortingDataAccessor` does a plain `row[columnId]` lookup, and most `matColumnDef` ids in the template don't match field names on `SmartAttributeModel`:

| Column id | Field actually displayed |
| --- | --- |
| `id` | `attribute.attribute_id` |
| `name` | `getAttributeName(attribute)` — `metadata.display_name` |
| `value` | `getAttributeValue(attribute)` — branches on `display_type` (raw vs transformed vs value) |
| `worst` | `getAttributeWorst(attribute)` |
| `thresh` | `getAttributeThreshold(attribute)` |
| `ideal` | `getAttributeIdeal(attribute)` — `metadata.ideal` |
| `failure` | `attribute.failure_rate` |
| `history` | sparkline chart (no scalar) |

So `row['id']`, `row['name']`, `row['ideal']`, `row['failure']`, `row['history']` all resolve to `undefined` and the sort silently no-ops. Only `status`, `value`, and `thresh` happened to match field names.

## Fix

Set `sortingDataAccessor` on `smartAttributeDataSource` in `ngAfterViewInit` to map each column id to the value actually rendered in that cell, reusing the existing `getAttribute*` getters so the sort key is always exactly what the user sees.

- `attribute_id` is coerced via `Number(...)` so numeric SMART ids sort numerically rather than lexicographically (e.g. `5, 10, 12` not `10, 12, 5`).
- `worst`/`thresh` getters can return either a number or `''` depending on display type — preserved as-is so empty cells group together.
- `history` has no meaningful scalar; exposing the latest observed value gives a deterministic order instead of a no-op when the user clicks the header.
- `default` branch falls through to the prior `row[id]` lookup so any future column id that matches a model field keeps working.

41 lines changed in one file: \`webapp/frontend/src/app/modules/detail/detail.component.ts\`.

## Verification

- \`npm ci && npx ng build\` — clean compile
- \`docker build -f docker/Dockerfile.web .\` — image builds end-to-end
- Manually verified each column (ID, Name, Value, Worst, Threshold, Ideal, Failure Rate, History) sorts ascending then descending against a live scrutiny instance on real disks

## AI disclosure (per AI_POLICY.md)

This PR was written with Claude Code (Opus 4.7) as a pair-programming assistant. I drove issue selection, read the codebase, decided the fix shape (\`sortingDataAccessor\` mapping), wrote the column-to-getter mapping, verified the build, and manually tested the sort against my own running scrutiny instance with attached disks. The AI assisted with grepping the codebase, drafting the accessor switch statement, and proofreading. No code was shipped that I haven't read end-to-end.