### PR TITLE
Fix device failed status not getting cleared when SMART data becomes clean

### DIFF
--- a/webapp/backend/pkg/database/scrutiny_repository_device.go
+++ b/webapp/backend/pkg/database/scrutiny_repository_device.go
@@ -54,14 +54,18 @@ func (sr *scrutinyRepository) UpdateDevice(ctx context.Context, scrutiny_uuid uu
 }
 
 // Update Device Status
+// The provided status reflects the latest full SMART analysis and replaces the previous value
+// outright, so a device that recovers (clean SMART data) is reset from failed back to passing.
 func (sr *scrutinyRepository) UpdateDeviceStatus(ctx context.Context, scrutiny_uuid uuid.UUID, status pkg.DeviceStatus) (models.Device, error) {
 	var device models.Device
 	if err := sr.gormClient.WithContext(ctx).Where("scrutiny_uuid = ?", scrutiny_uuid.String()).First(&device).Error; err != nil {
 		return device, fmt.Errorf("could not get device from DB: %v", err)
 	}
 
-	device.DeviceStatus = pkg.DeviceStatusSet(device.DeviceStatus, status)
-	return device, sr.gormClient.Model(&device).Updates(device).Error
+	device.DeviceStatus = status
+	// Use an explicit column update rather than Updates(device): GORM skips zero-valued struct
+	// fields, so a passing (zero) status would otherwise never overwrite a stored failed status.
+	return device, sr.gormClient.Model(&device).Where("scrutiny_uuid = ?", scrutiny_uuid.String()).Update("device_status", status).Error
 }
 
 func (sr *scrutinyRepository) GetDeviceDetails(ctx context.Context, scrutiny_uuid uuid.UUID) (models.Device, error) {

--- a/webapp/backend/pkg/models/device.go
+++ b/webapp/backend/pkg/models/device.go
@@ -169,9 +169,5 @@ func (dv *Device) UpdateFromCollectorSmartInfo(info collector.SmartInfo) error {
 	dv.Firmware = info.FirmwareVersion
 	dv.DeviceProtocol = info.Device.Protocol
 
-	if !info.SmartStatus.Passed {
-		dv.DeviceStatus = pkg.DeviceStatusSet(dv.DeviceStatus, pkg.DeviceStatusFailedSmart)
-	}
-
 	return nil
 }

--- a/webapp/backend/pkg/web/handler/upload_device_metrics.go
+++ b/webapp/backend/pkg/web/handler/upload_device_metrics.go
@@ -54,14 +54,14 @@ func UploadDeviceMetrics(c *gin.Context) {
 		return
 	}
 
-	if smartData.Status != pkg.DeviceStatusPassed {
-		//there is a failure detected by Scrutiny, update the device status on the homepage.
-		updatedDevice, err = deviceRepo.UpdateDeviceStatus(c, scrutiny_uuid, smartData.Status)
-		if err != nil {
-			logger.Errorln("An error occurred while updating device status", err)
-			c.JSON(http.StatusInternalServerError, gin.H{"success": false})
-			return
-		}
+	//update the device status on the homepage to match the latest SMART analysis. This is done
+	//unconditionally so that a device which previously failed but now reports clean SMART data is
+	//reset from a failed status back to passing.
+	updatedDevice, err = deviceRepo.UpdateDeviceStatus(c, scrutiny_uuid, smartData.Status)
+	if err != nil {
+		logger.Errorln("An error occurred while updating device status", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"success": false})
+		return
 	}
 
 	// save smart temperature data (ignore failures)

--- a/webapp/backend/pkg/web/server_test.go
+++ b/webapp/backend/pkg/web/server_test.go
@@ -577,3 +577,91 @@ func (suite *ServerTestSuite) TestGetDevicesSummaryRoute_Nvme() {
 	require.Equal(suite.T(), deviceUUID, deviceSummary.Data.Summary[deviceUUIDString].Device.ScrutinyUUID)
 	require.Equal(suite.T(), pkg.DeviceStatusPassed, deviceSummary.Data.Summary[deviceUUIDString].Device.DeviceStatus)
 }
+
+// TestGetDevicesSummaryRoute_DeviceStatusResetsToPassing is a regression test: a device that was
+// previously recorded as failed must be reset back to passing once it reports clean SMART data again.
+func (suite *ServerTestSuite) TestGetDevicesSummaryRoute_DeviceStatusResetsToPassing() {
+	//setup
+	parentPath, _ := os.MkdirTemp("", "")
+	defer os.RemoveAll(parentPath)
+	mockCtrl := gomock.NewController(suite.T())
+	fakeConfig := mock_config.NewMockInterface(mockCtrl)
+	fakeConfig.EXPECT().SetDefault(gomock.Any(), gomock.Any()).AnyTimes()
+	fakeConfig.EXPECT().UnmarshalKey(gomock.Any(), gomock.Any()).AnyTimes().Return(nil)
+	fakeConfig.EXPECT().GetString("web.database.location").AnyTimes().Return(path.Join(parentPath, "scrutiny_test.db"))
+	fakeConfig.EXPECT().GetString("web.src.frontend.path").AnyTimes().Return(parentPath)
+	fakeConfig.EXPECT().GetString("web.listen.basepath").Return(suite.Basepath).AnyTimes()
+	fakeConfig.EXPECT().GetString("web.influxdb.scheme").Return("http").AnyTimes()
+	fakeConfig.EXPECT().GetString("web.influxdb.port").Return("8086").AnyTimes()
+	fakeConfig.EXPECT().IsSet("web.influxdb.token").Return(true).AnyTimes()
+	fakeConfig.EXPECT().GetString("web.influxdb.token").Return("my-super-secret-auth-token").AnyTimes()
+	fakeConfig.EXPECT().GetString("web.influxdb.org").Return("scrutiny").AnyTimes()
+	fakeConfig.EXPECT().GetString("web.influxdb.bucket").Return("metrics").AnyTimes()
+	fakeConfig.EXPECT().GetBool("user.metrics.repeat_notifications").Return(true).AnyTimes()
+	fakeConfig.EXPECT().GetBool("user.collector.discard_sct_temp_history").Return(false).AnyTimes()
+	fakeConfig.EXPECT().GetBool("web.influxdb.tls.insecure_skip_verify").Return(false).AnyTimes()
+	fakeConfig.EXPECT().GetBool("web.influxdb.retention_policy").Return(false).AnyTimes()
+	fakeConfig.EXPECT().GetStringSlice("notify.urls").AnyTimes().Return([]string{})
+	fakeConfig.EXPECT().GetInt(fmt.Sprintf("%s.metrics.notify_level", config.DB_USER_SETTINGS_SUBKEY)).AnyTimes().Return(int(pkg.MetricsNotifyLevelFail))
+	fakeConfig.EXPECT().GetInt(fmt.Sprintf("%s.metrics.status_filter_attributes", config.DB_USER_SETTINGS_SUBKEY)).AnyTimes().Return(int(pkg.MetricsStatusFilterAttributesAll))
+	fakeConfig.EXPECT().GetInt(fmt.Sprintf("%s.metrics.status_threshold", config.DB_USER_SETTINGS_SUBKEY)).AnyTimes().Return(int(pkg.MetricsStatusThresholdBoth))
+
+	if _, isGithubActions := os.LookupEnv("GITHUB_ACTIONS"); isGithubActions {
+		// when running test suite in github actions, we run an influxdb service as a sidecar.
+		fakeConfig.EXPECT().GetString("web.influxdb.host").Return("influxdb").AnyTimes()
+	} else {
+		fakeConfig.EXPECT().GetString("web.influxdb.host").Return("localhost").AnyTimes()
+	}
+
+	ae := web.AppEngine{
+		Config: fakeConfig,
+	}
+	router := ae.Setup(logrus.WithField("test", suite.T().Name()))
+	devicesfile, err := os.Open("testdata/register-devices-req.json")
+	require.NoError(suite.T(), err)
+
+	// smart-fail2.json reports a failing device, smart-ata.json reports the same (ATA) device passing.
+	failfile := helperReadSmartDataFileFixTimestamp(suite.T(), "../models/testdata/smart-fail2.json")
+	passfile := helperReadSmartDataFileFixTimestamp(suite.T(), "../models/testdata/smart-ata.json")
+
+	deviceUUIDString := "3ea22b35-682b-49fb-a655-abffed108e48"
+
+	//test - register devices
+	wr := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", suite.Basepath+"/api/devices/register", devicesfile)
+	router.ServeHTTP(wr, req)
+	require.Equal(suite.T(), 200, wr.Code)
+
+	//test - upload failing SMART data
+	fr := httptest.NewRecorder()
+	req, _ = http.NewRequest("POST", suite.Basepath+"/api/device/"+deviceUUIDString+"/smart", failfile)
+	router.ServeHTTP(fr, req)
+	require.Equal(suite.T(), 200, fr.Code)
+
+	//assert - device is now failed
+	failSummary := helperGetDeviceSummary(suite.T(), router, suite.Basepath)
+	require.Equal(suite.T(), pkg.DeviceStatusFailedScrutiny|pkg.DeviceStatusFailedSmart, failSummary.Data.Summary[deviceUUIDString].Device.DeviceStatus)
+
+	//test - upload clean SMART data for the same device
+	pr := httptest.NewRecorder()
+	req, _ = http.NewRequest("POST", suite.Basepath+"/api/device/"+deviceUUIDString+"/smart", passfile)
+	router.ServeHTTP(pr, req)
+	require.Equal(suite.T(), 200, pr.Code)
+
+	//assert - device status is reset back to passing
+	passSummary := helperGetDeviceSummary(suite.T(), router, suite.Basepath)
+	require.Equal(suite.T(), pkg.DeviceStatusPassed, passSummary.Data.Summary[deviceUUIDString].Device.DeviceStatus)
+}
+
+func helperGetDeviceSummary(t *testing.T, router http.Handler, basepath string) models.DeviceSummaryWrapper {
+	t.Helper()
+	sr := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", basepath+"/api/summary", nil)
+	router.ServeHTTP(sr, req)
+	require.Equal(t, 200, sr.Code)
+
+	var deviceSummary models.DeviceSummaryWrapper
+	err := json.Unmarshal(sr.Body.Bytes(), &deviceSummary)
+	require.NoError(t, err)
+	return deviceSummary
+}


### PR DESCRIPTION
Also remove a redundant setting of the status bit