### PR TITLE
fix(web): skip persisting SMART metrics when smartctl could not read the device

### DIFF
--- a/webapp/backend/pkg/models/collector/smart.go
+++ b/webapp/backend/pkg/models/collector/smart.go
@@ -287,6 +287,44 @@ func (s *SmartInfo) Capacity() int64 {
 	return 0
 }
 
+// smartctl reports its result as an exit status bitmask (see smartmontools'
+// smartctl.h). The individual bits below indicate why smartctl set a non-zero
+// exit status:
+//
+//	bit 0 (0x01): the command line did not parse
+//	bit 1 (0x02): the device could not be opened, or is in a low-power/standby mode
+//	bit 2 (0x04): a SMART or ATA command to the device failed, or a checksum
+//	              error was found in a SMART data structure
+//
+// The remaining bits (3-7) report genuine health findings (SMART "FAILING"
+// status, pre-fail attributes, logged errors, etc.) whose data we still want
+// to keep, so they are intentionally not part of the mask below.
+const (
+	smartctlExitStatusCommandLineDidNotParse = 1 << 0 // 0x01
+	smartctlExitStatusDeviceOpenFailed       = 1 << 1 // 0x02
+)
+
+// smartctlExitStatusDataUnavailableMask covers the exit status bits that mean
+// smartctl could not actually read usable data off the device. When either is
+// set the JSON payload is largely uninitialized (empty model/serial, no
+// attributes, and a zero-value smart_status that looks like a SMART failure),
+// so it must not be persisted.
+//
+// Note that bit 2 (0x04) is deliberately excluded: RAID/megaraid passthrough
+// frequently sets it (smartctl cannot read some log pages through the
+// controller) while still returning a complete, valid identity + attribute set
+// - see testdata/smart-megaraid0.json (exit_status 4). Dropping that data would
+// regress monitoring for those drives.
+const smartctlExitStatusDataUnavailableMask = smartctlExitStatusCommandLineDidNotParse | smartctlExitStatusDeviceOpenFailed
+
+// HasInvalidData reports whether smartctl signalled, via its exit status
+// bitmask, that it could not read usable SMART data from the device. Callers
+// should skip persisting such payloads to avoid polluting the database with
+// uninitialized values (which otherwise get stored as a bogus SMART failure).
+func (s *SmartInfo) HasInvalidData() bool {
+	return s.Smartctl.ExitStatus&smartctlExitStatusDataUnavailableMask != 0
+}
+
 type UserCapacity struct {
 	Blocks int64 `json:"blocks"`
 	Bytes  int64 `json:"bytes"`

--- a/webapp/backend/pkg/models/collector/smart_test.go
+++ b/webapp/backend/pkg/models/collector/smart_test.go
@@ -2,6 +2,7 @@ package collector
 
 import (
 	"encoding/json"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -85,4 +86,58 @@ func TestSmartSupport_UnmarshalJSON(t *testing.T) {
 func TestSmartSupport_UnmarshalJSONInvalid(t *testing.T) {
 	var support SmartSupport
 	require.Error(t, json.Unmarshal([]byte(`"unsupported"`), &support))
+}
+
+func TestSmartInfo_HasInvalidData(t *testing.T) {
+	newSmartInfo := func(exitStatus int) SmartInfo {
+		var smartInfo SmartInfo
+		smartInfo.Smartctl.ExitStatus = exitStatus
+		return smartInfo
+	}
+
+	for _, tt := range []struct {
+		name       string
+		exitStatus int
+		invalid    bool
+	}{
+		{name: "clean run", exitStatus: 0x00, invalid: false},
+		{name: "commandline did not parse (bit 0)", exitStatus: 0x01, invalid: true},
+		{name: "device open failed / standby (bit 1)", exitStatus: 0x02, invalid: true},
+		{name: "checksum or command error (bit 2) keeps data", exitStatus: 0x04, invalid: false},
+		{name: "failing disk (bit 3) keeps data", exitStatus: 0x08, invalid: false},
+		{name: "prefail attributes (bit 4) keeps data", exitStatus: 0x10, invalid: false},
+		{name: "health findings 0xD8 keeps data", exitStatus: 0xD8, invalid: false},
+		{name: "open failed alongside health findings", exitStatus: 0x02 | 0x08, invalid: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			smartInfo := newSmartInfo(tt.exitStatus)
+			assert.Equal(t, tt.invalid, smartInfo.HasInvalidData())
+		})
+	}
+}
+
+func TestSmartInfo_HasInvalidData_Fixtures(t *testing.T) {
+	for _, tt := range []struct {
+		fixture string
+		invalid bool
+	}{
+		// clean read of a healthy drive
+		{fixture: "smart-ata.json", invalid: false},
+		// smartctl could not open the device (exit_status 2); payload is empty
+		{fixture: "smart-fail.json", invalid: true},
+		// genuinely failing drive with a complete payload (exit_status 216)
+		{fixture: "smart-fail2.json", invalid: false},
+		// megaraid passthrough sets bit 2 (exit_status 4) but returns valid data
+		{fixture: "smart-megaraid0.json", invalid: false},
+	} {
+		t.Run(tt.fixture, func(t *testing.T) {
+			contents, err := os.ReadFile("../testdata/" + tt.fixture)
+			require.NoError(t, err)
+
+			var smartInfo SmartInfo
+			require.NoError(t, json.Unmarshal(contents, &smartInfo))
+
+			assert.Equal(t, tt.invalid, smartInfo.HasInvalidData())
+		})
+	}
 }

--- a/webapp/backend/pkg/web/handler/upload_device_metrics.go
+++ b/webapp/backend/pkg/web/handler/upload_device_metrics.go
@@ -38,6 +38,15 @@ func UploadDeviceMetrics(c *gin.Context) {
 		return
 	}
 
+	// smartctl could not read usable data off the device (eg. the device could
+	// not be opened or is in standby). The payload is largely uninitialized and
+	// would otherwise be stored as a bogus SMART failure, so skip persisting it.
+	if collectorSmartData.HasInvalidData() {
+		logger.Warnf("smartctl reported it could not read the device (exit status %d); skipping metrics to avoid storing invalid data", collectorSmartData.Smartctl.ExitStatus)
+		c.JSON(http.StatusOK, gin.H{"success": true})
+		return
+	}
+
 	//update the device information if necessary
 	updatedDevice, err := deviceRepo.UpdateDevice(c, scrutiny_uuid, collectorSmartData)
 	if err != nil {

--- a/webapp/backend/pkg/web/server_test.go
+++ b/webapp/backend/pkg/web/server_test.go
@@ -224,6 +224,76 @@ func (suite *ServerTestSuite) TestUploadDeviceMetricsRoute() {
 	//assert
 }
 
+// smartctl can exit non-zero because it could not read the device (eg. the
+// device is in standby, or could not be opened). In that case the JSON payload
+// is largely uninitialized and must not be persisted (see issue #944).
+func (suite *ServerTestSuite) TestUploadDeviceMetricsRoute_SkipsUnreadableDevice() {
+	//setup
+	parentPath, _ := os.MkdirTemp("", "")
+	defer os.RemoveAll(parentPath)
+	mockCtrl := gomock.NewController(suite.T())
+	fakeConfig := mock_config.NewMockInterface(mockCtrl)
+	fakeConfig.EXPECT().SetDefault(gomock.Any(), gomock.Any()).AnyTimes()
+	fakeConfig.EXPECT().UnmarshalKey(gomock.Any(), gomock.Any()).AnyTimes().Return(nil)
+	fakeConfig.EXPECT().GetString("web.database.location").AnyTimes().Return(path.Join(parentPath, "scrutiny_test.db"))
+	fakeConfig.EXPECT().GetString("web.src.frontend.path").AnyTimes().Return(parentPath)
+	fakeConfig.EXPECT().GetString("web.listen.basepath").Return(suite.Basepath).AnyTimes()
+	fakeConfig.EXPECT().GetString("web.influxdb.scheme").Return("http").AnyTimes()
+	fakeConfig.EXPECT().GetString("web.influxdb.port").Return("8086").AnyTimes()
+	fakeConfig.EXPECT().IsSet("web.influxdb.token").Return(true).AnyTimes()
+	fakeConfig.EXPECT().GetString("web.influxdb.token").Return("my-super-secret-auth-token").AnyTimes()
+	fakeConfig.EXPECT().GetString("web.influxdb.org").Return("scrutiny").AnyTimes()
+	fakeConfig.EXPECT().GetString("web.influxdb.bucket").Return("metrics").AnyTimes()
+	fakeConfig.EXPECT().GetBool("user.metrics.repeat_notifications").Return(true).AnyTimes()
+	fakeConfig.EXPECT().GetBool("user.collector.discard_sct_temp_history").Return(false).AnyTimes()
+	fakeConfig.EXPECT().GetBool("web.influxdb.tls.insecure_skip_verify").Return(false).AnyTimes()
+	fakeConfig.EXPECT().GetBool("web.influxdb.retention_policy").Return(false).AnyTimes()
+	if _, isGithubActions := os.LookupEnv("GITHUB_ACTIONS"); isGithubActions {
+		// when running test suite in github actions, we run an influxdb service as a sidecar.
+		fakeConfig.EXPECT().GetString("web.influxdb.host").Return("influxdb").AnyTimes()
+	} else {
+		fakeConfig.EXPECT().GetString("web.influxdb.host").Return("localhost").AnyTimes()
+	}
+	fakeConfig.EXPECT().GetInt(fmt.Sprintf("%s.metrics.notify_level", config.DB_USER_SETTINGS_SUBKEY)).AnyTimes().Return(int(pkg.MetricsNotifyLevelFail))
+	fakeConfig.EXPECT().GetInt(fmt.Sprintf("%s.metrics.status_filter_attributes", config.DB_USER_SETTINGS_SUBKEY)).AnyTimes().Return(int(pkg.MetricsStatusFilterAttributesAll))
+	fakeConfig.EXPECT().GetInt(fmt.Sprintf("%s.metrics.status_threshold", config.DB_USER_SETTINGS_SUBKEY)).AnyTimes().Return(int(pkg.MetricsStatusThresholdBoth))
+
+	ae := web.AppEngine{
+		Config: fakeConfig,
+	}
+	router := ae.Setup(logrus.WithField("test", suite.T().Name()))
+	devicesfile, err := os.Open("testdata/register-devices-single-req.json")
+	require.NoError(suite.T(), err)
+
+	// smart-fail.json has exit_status 2 (smartctl could not open the device)
+	failfile := helperReadSmartDataFileFixTimestamp(suite.T(), "../models/testdata/smart-fail.json")
+
+	//test
+	wr := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", suite.Basepath+"/api/devices/register", devicesfile)
+	router.ServeHTTP(wr, req)
+	require.Equal(suite.T(), 200, wr.Code)
+
+	mr := httptest.NewRecorder()
+	req, _ = http.NewRequest("POST", suite.Basepath+"/api/device/9a4d34b5-b2ee-51ef-8506-90eea09be417/smart", failfile)
+	router.ServeHTTP(mr, req)
+	require.Equal(suite.T(), 200, mr.Code)
+
+	//assert: the unreadable payload must not have been persisted
+	dr := httptest.NewRecorder()
+	req, _ = http.NewRequest("GET", suite.Basepath+"/api/device/9a4d34b5-b2ee-51ef-8506-90eea09be417/details", nil)
+	router.ServeHTTP(dr, req)
+	require.Equal(suite.T(), 200, dr.Code)
+
+	var detailsResponse struct {
+		Data struct {
+			SmartResults []interface{} `json:"smart_results"`
+		} `json:"data"`
+	}
+	require.NoError(suite.T(), json.Unmarshal(dr.Body.Bytes(), &detailsResponse))
+	require.Empty(suite.T(), detailsResponse.Data.SmartResults)
+}
+
 func (suite *ServerTestSuite) TestPopulateMultiple() {
 	//setup
 	parentPath, _ := os.MkdirTemp("", "")


### PR DESCRIPTION
Fixes #944

smartctl reports its result as an exit-status bitmask. When bit 0 (command line did not parse) or bit 1 (device open failed / low-power mode) is set, the JSON payload is largely uninitialized — empty model/serial, no attributes, and a zero-value `smart_status` that the backend reads as a SMART failure. `UploadDeviceMetrics` persisted this unconditionally, so a drive that was merely in standby or couldn't be opened got stored as a bogus *failing* device (and could even trigger failure notifications).

**Change:** add `SmartInfo.HasInvalidData()`, which inspects the smartctl exit-status bitmask, and skip persisting the payload in the upload handler when it's set.

**Note on bit 2:** the issue suggested skipping on bits 0-2, but I scoped this to bits 0-1 and deliberately excluded bit 2 (0x04 — checksum / SMART-command error). RAID/megaraid passthrough sets bit 2 while still returning valid data (`testdata/smart-megaraid0.json`, exit_status 4: full model + 20 attributes + health), so dropping it would regress those drives. Happy to widen the mask if you'd prefer — flagging it for your call.

**Testing:** unit tests over the exit-status bitmask (synthetic values + `smart-ata`/`smart-fail`/`smart-fail2`/`smart-megaraid0` fixtures) and an end-to-end handler test (real InfluxDB) asserting an exit-2 payload yields zero stored `smart_results`. `go test ./webapp/backend/pkg/models/collector/... ./webapp/backend/pkg/web/...` passes; `gofmt`/`go vet` clean. I do not have megaraid/RAID hardware, so that path was preserved rather than modified and not hardware-tested.

**AI disclosure (per `AI_POLICY.md`):** implemented with AI assistance (Claude Code). All code and tests were reviewed and verified by me by running the tests locally against a real InfluxDB instance; the bit-2/megaraid scoping decision was made deliberately based on the committed fixtures.
