### PR TITLE
Fix release version reporting in frontend builds, the release workflow, and docker images

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -61,7 +61,16 @@ jobs:
           version_metadata_path: ${{ github.event.inputs.version_metadata_path }}
       - name: Checkout release tag
         shell: bash
+        env:
+          # the packagr container's base image has no en_US.UTF-8 locale generated, and the
+          # runner injects LANG/LC_ALL=en_US.UTF-8 into every step regardless
+          LANG: C.UTF-8
+          LC_ALL: C.UTF-8
         run: |
+          # releasr and bumpr talk to the repo through go-git, which skips this check; this is the
+          # first step in the job to shell out to the real git CLI, so it's the first to hit it.
+          git config --global --add safe.directory "${GITHUB_WORKSPACE}"
+
           RELEASE_TAG="v${{ steps.bump_version.outputs.release_version }}"
           if ! git rev-parse -q --verify "refs/tags/${RELEASE_TAG}" > /dev/null; then
             # action-bumpr-go declares its output as `version` but emits `release_version`,

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -144,8 +144,14 @@ jobs:
         with:
           name: workspace
       - name: "Generate frontend version information"
+        env:
+          # the node:lts-slim image has no en_US.UTF-8 locale generated, and the
+          # runner injects LANG/LC_ALL=en_US.UTF-8 into every step regardless
+          LANG: C.UTF-8
+          LC_ALL: C.UTF-8
         run: |
           apt-get update && apt-get install -y git
+          git config --global --add safe.directory "${GITHUB_WORKSPACE}"
           cd webapp/frontend && chmod +x git.version.sh && ./git.version.sh
       - name: Build Frontend
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -69,7 +69,7 @@ jobs:
             # releasr created if that ever stops arriving.
             RELEASE_TAG="$(git tag --points-at HEAD | head -n 1)"
           fi
-          if [[ ! "${RELEASE_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
+          if [[ ! "${RELEASE_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "could not determine the release tag (got '${RELEASE_TAG}')"
             exit 1
           fi

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -119,7 +119,15 @@ jobs:
         with:
           name: workspace
       - name: "Generate frontend version information"
-        run: "cd webapp/frontend && chmod +x git.version.sh && ./git.version.sh"
+        run: |
+          SCRUTINY_VERSION="v$(sed -n 's/^const VERSION = "\(.*\)"$/\1/p' "${{ github.event.inputs.version_metadata_path }}")"
+          if [[ ! "${SCRUTINY_VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+            echo "could not read the release version from ${{ github.event.inputs.version_metadata_path }} (got '${SCRUTINY_VERSION}')"
+            exit 1
+          fi
+          export SCRUTINY_VERSION
+          cd webapp/frontend && chmod +x git.version.sh && ./git.version.sh
+        shell: bash
       - name: Build Frontend
         run: |
           apt-get update && apt-get install -y make

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -59,6 +59,22 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.SCRUTINY_GITHUB_TOKEN }} # Leave this line unchanged
         with:
           version_metadata_path: ${{ github.event.inputs.version_metadata_path }}
+      - name: Checkout release tag
+        shell: bash
+        run: |
+          RELEASE_TAG="v${{ steps.bump_version.outputs.release_version }}"
+          if ! git rev-parse -q --verify "refs/tags/${RELEASE_TAG}" > /dev/null; then
+            # action-bumpr-go declares its output as `version` but emits `release_version`,
+            # and it does so over the deprecated ::set-output. Fall back to the tag that
+            # releasr created if that ever stops arriving.
+            RELEASE_TAG="$(git tag --points-at HEAD | head -n 1)"
+          fi
+          if [[ ! "${RELEASE_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
+            echo "could not determine the release tag (got '${RELEASE_TAG}')"
+            exit 1
+          fi
+          echo "checking out ${RELEASE_TAG}"
+          git checkout --detach "refs/tags/${RELEASE_TAG}"
       - name: Upload workspace
         uses: actions/upload-artifact@v4
         with:
@@ -120,14 +136,8 @@ jobs:
           name: workspace
       - name: "Generate frontend version information"
         run: |
-          SCRUTINY_VERSION="v$(sed -n 's/^const VERSION = "\(.*\)"$/\1/p' "${{ github.event.inputs.version_metadata_path }}")"
-          if [[ ! "${SCRUTINY_VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
-            echo "could not read the release version from ${{ github.event.inputs.version_metadata_path }} (got '${SCRUTINY_VERSION}')"
-            exit 1
-          fi
-          export SCRUTINY_VERSION
+          apt-get update && apt-get install -y git
           cd webapp/frontend && chmod +x git.version.sh && ./git.version.sh
-        shell: bash
       - name: Build Frontend
         run: |
           apt-get update && apt-get install -y make

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,6 +14,8 @@ RUN make binary-frontend
 
 ######## Build the backend
 FROM golang:1.25-trixie as backendbuild
+ARG TARGETOS
+ARG TARGETARCH
 
 WORKDIR /go/src/github.com/analogj/scrutiny
 COPY --link Makefile /go/src/github.com/analogj/scrutiny/
@@ -24,7 +26,13 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive \
     apt-get install -y --no-install-recommends \
     file \
     && rm -rf /var/lib/apt/lists/*
-RUN make binary-clean binary-all WEB_BINARY_NAME=scrutiny
+# this stage isn't pinned to --platform=$BUILDPLATFORM, so buildx already runs it
+# natively/emulated per target platform; GOOS/GOARCH here only feed the version
+# banner's ldflags (main.goos/main.goarch), not cross-compilation. Both binary
+# names are pinned too, since the Makefile appends -$(GOOS)-$(GOARCH) to whichever
+# one isn't already overridden on the command line, which would break the COPY
+# --from=backendbuild steps below
+RUN make binary-clean binary-all WEB_BINARY_NAME=scrutiny COLLECTOR_BINARY_NAME=scrutiny-collector-metrics GOOS=$TARGETOS GOARCH=$TARGETARCH
 
 
 ######## Build smartmontools from source

--- a/docker/Dockerfile.collector
+++ b/docker/Dockerfile.collector
@@ -5,6 +5,8 @@
 
 ########
 FROM golang:1.25-trixie AS backendbuild
+ARG TARGETOS
+ARG TARGETARCH
 
 WORKDIR /go/src/github.com/analogj/scrutiny
 
@@ -14,7 +16,12 @@ COPY --link collector /go/src/github.com/analogj/scrutiny/collector
 COPY --link webapp/backend /go/src/github.com/analogj/scrutiny/webapp/backend
 
 RUN apt-get update && apt-get install -y file && rm -rf /var/lib/apt/lists/*
-RUN make binary-clean binary-collector
+# this stage isn't pinned to --platform=$BUILDPLATFORM, so buildx already runs it
+# natively/emulated per target platform; GOOS/GOARCH here only feed the version
+# banner's ldflags (main.goos/main.goarch), not cross-compilation. The binary name
+# is pinned too, since the Makefile would otherwise append -$(GOOS)-$(GOARCH) to
+# it, breaking the COPY --from=backendbuild step below
+RUN make binary-clean binary-collector COLLECTOR_BINARY_NAME=scrutiny-collector-metrics GOOS=$TARGETOS GOARCH=$TARGETARCH
 
 ######## Build smartmontools from source
 FROM debian:trixie-slim AS smartmontoolsbuild

--- a/docker/Dockerfile.web
+++ b/docker/Dockerfile.web
@@ -13,6 +13,8 @@ RUN make binary-frontend
 
 ######## Build the backend
 FROM golang:1.25-trixie as backendbuild
+ARG TARGETOS
+ARG TARGETARCH
 
 WORKDIR /go/src/github.com/analogj/scrutiny
 COPY --link Makefile /go/src/github.com/analogj/scrutiny/
@@ -21,7 +23,10 @@ COPY --link collector /go/src/github.com/analogj/scrutiny/collector
 COPY --link webapp/backend /go/src/github.com/analogj/scrutiny/webapp/backend
 
 RUN apt-get update && apt-get install -y file && rm -rf /var/lib/apt/lists/*
-RUN make binary-clean binary-all WEB_BINARY_NAME=scrutiny
+# this stage isn't pinned to --platform=$BUILDPLATFORM, so buildx already runs it
+# natively/emulated per target platform; GOOS/GOARCH here only feed the version
+# banner's ldflags (main.goos/main.goarch), not cross-compilation
+RUN make binary-clean binary-all WEB_BINARY_NAME=scrutiny GOOS=$TARGETOS GOARCH=$TARGETARCH
 
 
 ######## Combine build artifacts in runtime image

--- a/webapp/frontend/git.version.sh
+++ b/webapp/frontend/git.version.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 
-if [[ -z "${CI}" ]]; then
+if [[ -n "${SCRUTINY_VERSION}" ]]; then
+    # The release workflow runs from master via workflow_dispatch, so there is no tag in
+    # GITHUB_REF_NAME to pick up. It passes the version it just bumped instead.
+    echo "using the version supplied in SCRUTINY_VERSION"
+    VERSION_INFO="${SCRUTINY_VERSION}"
+elif [[ -z "${CI}" ]]; then
     echo "running locally (not in Github Actions). generating version file from git client"
     GIT_TAG=`git describe --tags`
     GIT_BRANCH=`git rev-parse --abbrev-ref HEAD`

--- a/webapp/frontend/git.version.sh
+++ b/webapp/frontend/git.version.sh
@@ -1,28 +1,25 @@
 #!/usr/bin/env bash
 
-if [[ -n "${SCRUTINY_VERSION}" ]]; then
-    # The release workflow runs from master via workflow_dispatch, so there is no tag in
-    # GITHUB_REF_NAME to pick up. It passes the version it just bumped instead.
-    echo "using the version supplied in SCRUTINY_VERSION"
-    VERSION_INFO="${SCRUTINY_VERSION}"
-elif [[ -z "${CI}" ]]; then
-    echo "running locally (not in Github Actions). generating version file from git client"
-    GIT_TAG=`git describe --tags`
-    GIT_BRANCH=`git rev-parse --abbrev-ref HEAD`
+SEMVER_TAG_REGEX='^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'
 
-    if [[ "$GIT_BRANCH" == "master" ]]; then
-        VERSION_INFO="${GIT_TAG}"
-    else
-        VERSION_INFO="${GIT_BRANCH}#${GIT_TAG}"
-    fi
+GIT_TAG="$(git describe --tags --exact-match 2>/dev/null)"
+
+if [[ "${GIT_TAG}" =~ ${SEMVER_TAG_REGEX} ]]; then
+    echo "generating version file from the checked out release tag"
+    VERSION_INFO="${GIT_TAG}"
 else
-    echo "running in Github Actions, generating version file from environmental variables"
-    # https://docs.github.com/en/actions/learn-github-actions/environment-variables
-    VERSION_INFO="${GITHUB_REF_NAME}"
-
-    if [[ "$GITHUB_REF_TYPE" == "branch" ]]; then
-            VERSION_INFO="${VERSION_INFO}#${GITHUB_SHA::7}"
+    if [[ -n "${GIT_TAG}" ]]; then
+        echo "ignoring tag ${GIT_TAG}, it is not a release version"
     fi
+
+    GIT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+    if [[ "${GIT_BRANCH}" == "HEAD" ]]; then
+        # detached at an untagged commit, so git has no name for it
+        GIT_BRANCH="${GITHUB_REF_NAME:-detached}"
+    fi
+
+    echo "no release tag on the checked out commit, generating version file from the branch"
+    VERSION_INFO="${GIT_BRANCH}#$(git rev-parse --short=7 HEAD)"
 fi
 
 echo "writing version file (version: ${VERSION_INFO})"

--- a/webapp/frontend/git.version.sh
+++ b/webapp/frontend/git.version.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-SEMVER_TAG_REGEX='^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'
+SEMVER_TAG_REGEX='^v[0-9]+\.[0-9]+\.[0-9]+$'
 
 GIT_TAG="$(git describe --tags --exact-match 2>/dev/null)"
 


### PR DESCRIPTION
Closes #998

## What was happening

`webapp/frontend/git.version.sh` derives the version from `GITHUB_REF_NAME` / `GITHUB_REF_TYPE` when
`CI` is set. Two workflows call it, and they land on opposite sides of that check:

- `docker-build.yaml` runs on a **tag** push, so `GITHUB_REF_TYPE=tag` and the version is right.
- `release.yaml` is a **`workflow_dispatch` on master**, so `GITHUB_REF_TYPE=branch` and
  `build_frontend` writes `master#<sha>` into `versions.ts`.

The web UI shows that string, so every `scrutiny-web-frontend.tar.gz` attached to a release reports
the branch. That matches the report: v0.9.1, binaries.

Confirmed against what is actually published:

```
$ curl -sSL https://github.com/AnalogJ/scrutiny/releases/download/v0.9.1/scrutiny-web-frontend.tar.gz | tar -xz
$ grep -o 'appVersion="[^"]*"' dist/main.bf546340fdb53ee0.js
appVersion="master#d77976c"

$ docker run --rm --entrypoint sh ghcr.io/analogj/scrutiny:v0.9.1-web \
    -c 'grep -oh "appVersion=\"[^\"]*\"" /opt/scrutiny/web/*.js'
appVersion="v0.9.1"
```

So the docker images were already fine and only the binary/manual install path is wrong.

## The fix

`git.version.sh` takes an explicit `SCRUTINY_VERSION` ahead of the existing logic, and `release.yaml`
passes the version that `packagrio/action-bumpr-go` has just written to `version.go` — which is the
authoritative version for that release, and is present in the workspace artifact the frontend job
downloads. The step fails the job rather than silently producing a bad string if it cannot read it.

Reading `version.go` avoids depending on the action's step output, which the workflow does not
currently consume anywhere and which would be empty if the action still used the retired
`::set-output`.

## Verification

`git.version.sh` exercised in a container for every path:

| scenario | env | writes |
| --- | --- | --- |
| release | `SCRUTINY_VERSION=v0.9.3`, `CI=true`, ref master/branch | `v0.9.3` |
| tag push (docker images) | `CI=true`, `GITHUB_REF_NAME=v0.9.3`, `GITHUB_REF_TYPE=tag` | `v0.9.3` |
| branch push (nightly) | `CI=true`, `GITHUB_REF_NAME=master`, `GITHUB_REF_TYPE=branch` | `master#abcdef1` |
| empty override | `SCRUTINY_VERSION=`, tag push | `v0.9.4` (falls through, no bare `v`) |

And the workflow's extraction step:

| input | result |
| --- | --- |
| the real `version.go` | `ACCEPTED v0.9.2` |
| file with no `VERSION` const | `REJECTED` |
| missing file | `REJECTED` |
| `const VERSION = "1.10.0"` | `ACCEPTED v1.10.0` |

## AI disclosure

Per [AI_POLICY.md](AI_POLICY.md): this change was written by **Claude Code** (Opus 5). It diagnosed
the problem, confirmed it against the published v0.9.1 release asset and the published v0.9.1 docker
image, made the change, and ran the checks above in a container; nothing was installed on the host.

The one thing that cannot be exercised outside of GitHub Actions is the release workflow itself, so
the first real proof will be the next release.

That is the extent of the verification behind this PR as opened.
