### PR TITLE
Fix frontend development mocks

### DIFF
--- a/webapp/frontend/src/app/app.module.ts
+++ b/webapp/frontend/src/app/app.module.ts
@@ -12,6 +12,7 @@ import {mockDataServices} from 'app/data/mock';
 import {LayoutModule} from 'app/layout/layout.module';
 import {AppComponent} from 'app/app.component';
 import {appRoutes, getAppBaseHref} from 'app/app.routing';
+import {environment} from 'environments/environment';
 
 const routerConfig: ExtraOptions = {
     scrollPositionRestoration: 'enabled',
@@ -23,8 +24,7 @@ let dev = [
 ];
 
 // if production clear dev imports and set to prod mode
-// @ts-ignore
-if (process.env.NODE_ENV === 'production') {
+if (environment.production) {
     dev = [];
     enableProdMode();
 }

--- a/webapp/frontend/src/app/data/mock/index.ts
+++ b/webapp/frontend/src/app/data/mock/index.ts
@@ -1,7 +1,9 @@
 import { SummaryMockApi } from 'app/data/mock/summary';
 import { DetailsMockApi } from 'app/data/mock/device/details';
+import { SettingsMockApi } from 'app/data/mock/settings';
 
 export const mockDataServices = [
+    SettingsMockApi,
     SummaryMockApi,
     DetailsMockApi,
 ];

--- a/webapp/frontend/src/app/data/mock/settings/index.ts
+++ b/webapp/frontend/src/app/data/mock/settings/index.ts
@@ -1,0 +1,37 @@
+import {Injectable} from '@angular/core';
+import {HttpRequest} from '@angular/common/http';
+import * as _ from 'lodash';
+import {TreoMockApi} from '@treo/lib/mock-api/mock-api.interfaces';
+import {TreoMockApiService} from '@treo/lib/mock-api/mock-api.service';
+import {AppConfig, appConfig} from 'app/core/config/app.config';
+
+@Injectable({
+    providedIn: 'root'
+})
+export class SettingsMockApi implements TreoMockApi {
+    private _settings: AppConfig = _.cloneDeep(appConfig);
+
+    constructor(private _treoMockApiService: TreoMockApiService) {
+        this.register();
+    }
+
+    register(): void {
+        this._treoMockApiService
+            .onGet('/api/settings')
+            .reply(() => [
+                200,
+                {success: true, settings: _.cloneDeep(this._settings)}
+            ]);
+
+        this._treoMockApiService
+            .onPost('/api/settings')
+            .reply((request: HttpRequest<AppConfig>) => {
+                this._settings = _.cloneDeep(request.body);
+
+                return [
+                    200,
+                    {success: true, settings: _.cloneDeep(this._settings)}
+                ];
+            });
+    }
+}


### PR DESCRIPTION
Fixes #1047.

## Summary

- use Angular's `environment.production` flag to control development mock registration
- add development mocks for `GET /api/settings` and `POST /api/settings`
- retain settings changes in memory for the current development session

## Verification

- ran `npx tsc --noEmit -p tsconfig.app.json`
- ran the Angular development server using the documented mock-data workflow
- manually verified that `/web/dashboard` loads with mock device data
- manually verified that `/api/settings` no longer returns 404 during application startup

The optimized production build was started but not completed in the constrained ARM64 development environment, so it is not represented as passing here.

## AI usage disclosure

I used OpenAI Codex to help inspect the repository, diagnose the development workflow, prepare the implementation, and draft this PR description. I personally reproduced the original problem, reviewed the changes, and manually verified the resulting UI.