### PR TITLE
Implement per-drive PDF export reports

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,6 +1,7 @@
 {
     "version": "0.2.0",
     "configurations": [
+
         {
             "name": "Run Scrutiny",
             "type": "go",
@@ -32,6 +33,50 @@
                 "COLLECTOR_DEBUG": "true"
             },
             "console": "integratedTerminal"
+        },
+        {
+            "name": "Run Scrutiny for Dummy Data",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${workspaceFolder}/webapp/backend/cmd/scrutiny/scrutiny.go",
+            "args": ["start", "--config", "./scrutiny.yaml"],
+            "cwd": "${workspaceFolder}",
+            "env": {
+                "DEBUG": "true"
+            },
+            "console": "integratedTerminal",
+            "preLaunchTask": "Build Frontend",
+            "presentation": {
+                "hidden": true
+            }
+        },
+        {
+            "name": "Load Dummy Data",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${workspaceFolder}/webapp/backend/pkg/models/testdata/helper.go",
+            "cwd": "${workspaceFolder}",
+            "console": "integratedTerminal",
+            "serverReadyAction": {
+                "action": "openExternally",
+                "pattern": "Dummy data loaded",
+                "uriFormat": "http://localhost:8080/web/"
+            },
+            "presentation": {
+                "hidden": true
+            }
+        }
+    ],
+    "compounds": [
+        {
+            "name": "Run Scrutiny with Dummy Data",
+            "configurations": [
+                "Run Scrutiny for Dummy Data",
+                "Load Dummy Data"
+            ],
+            "stopAll": true
         }
     ]
 }

--- a/webapp/backend/pkg/models/testdata/helper.go
+++ b/webapp/backend/pkg/models/testdata/helper.go
@@ -10,20 +10,24 @@ import (
 	"os"
 	"time"
 
+	"github.com/analogj/scrutiny/webapp/backend/pkg/models"
 	"github.com/analogj/scrutiny/webapp/backend/pkg/models/collector"
 )
 
 func main() {
+	if err := waitForServer("http://localhost:8080/api/health", time.Minute); err != nil {
+		log.Fatalf("ERROR %v", err)
+	}
 
 	//webapp/backend/pkg/web/testdata/register-devices-req.json
 	devices := "webapp/backend/pkg/web/testdata/register-devices-req.json"
 
 	smartData := map[string][]string{
-		"0x5000cca264eb01d7": {"webapp/backend/pkg/models/testdata/smart-ata.json", "webapp/backend/pkg/models/testdata/smart-ata-date.json", "webapp/backend/pkg/models/testdata/smart-ata-date2.json"},
-		"0x5000cca264ec3183": {"webapp/backend/pkg/models/testdata/smart-fail2.json"},
-		"0x5002538e40a22954": {"webapp/backend/pkg/models/testdata/smart-nvme.json"},
-		"0x5000cca252c859cc": {"webapp/backend/pkg/models/testdata/smart-scsi.json"},
-		"0x5000cca264ebc248": {"webapp/backend/pkg/models/testdata/smart-scsi2.json"},
+		"3ea22b35-682b-49fb-a655-abffed108e48": {"webapp/backend/pkg/models/testdata/smart-ata.json", "webapp/backend/pkg/models/testdata/smart-ata-date.json", "webapp/backend/pkg/models/testdata/smart-ata-date2.json"},
+		"42caca8a-9b95-5c75-b059-305771a2a193": {"webapp/backend/pkg/models/testdata/smart-fail2.json"},
+		"ecfaaf20-d1f6-558b-b33a-3e8db19a6c2c": {"webapp/backend/pkg/models/testdata/smart-nvme.json"},
+		"d8796fe7-2422-520c-8991-e970993dad3e": {"webapp/backend/pkg/models/testdata/smart-scsi.json"},
+		"00328b73-9f8a-53ad-8f20-8d0b1be00f47": {"webapp/backend/pkg/models/testdata/smart-scsi2.json"},
 	}
 
 	// send a post request to register devices
@@ -56,6 +60,64 @@ func main() {
 
 	}
 
+	// Add a second daily reading with a visible temperature and power-on-hours
+	// trend to one drive, so its detail charts contain richer sample data.
+	for daysToSubtract := 0; daysToSubtract <= 30; daysToSubtract++ {
+		smartDataReader, err := readSmartDataFileWithTrend(daysToSubtract, "webapp/backend/pkg/models/testdata/smart-ata.json")
+		if err != nil {
+			log.Fatalf("ERROR %v", err)
+		}
+
+		_, err = SendPostRequest("http://localhost:8080/api/device/3ea22b35-682b-49fb-a655-abffed108e48/smart", smartDataReader)
+		if err != nil {
+			log.Fatalf("ERROR %v", err)
+		}
+	}
+
+	if err := waitForDummyData("http://localhost:8080/api/summary", "3ea22b35-682b-49fb-a655-abffed108e48", 10*time.Second); err != nil {
+		log.Fatalf("ERROR %v", err)
+	}
+	log.Println("Dummy data loaded")
+
+}
+
+func waitForServer(url string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		response, err := http.Get(url)
+		if err == nil {
+			response.Body.Close()
+			if response.StatusCode >= http.StatusOK && response.StatusCode < http.StatusMultipleChoices {
+				return nil
+			}
+		}
+
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	return fmt.Errorf("timed out waiting for %s", url)
+}
+
+func waitForDummyData(url string, scrutinyUUID string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		response, err := http.Get(url)
+		if err == nil {
+			var summary models.DeviceSummaryWrapper
+			decodeErr := json.NewDecoder(response.Body).Decode(&summary)
+			response.Body.Close()
+			if decodeErr == nil && response.StatusCode == http.StatusOK {
+				deviceSummary := summary.Data.Summary[scrutinyUUID]
+				if deviceSummary != nil && deviceSummary.SmartResults != nil {
+					return nil
+				}
+			}
+		}
+
+		time.Sleep(250 * time.Millisecond)
+	}
+
+	return fmt.Errorf("dummy SMART data was submitted but did not appear in %s", url)
 }
 
 func SendPostRequest(url string, file io.Reader) ([]byte, error) {
@@ -65,14 +127,30 @@ func SendPostRequest(url string, file io.Reader) ([]byte, error) {
 	}
 	defer response.Body.Close()
 
-	log.Printf("%v\n", response.Status)
+	responseBody, err := io.ReadAll(response.Body)
+	if err != nil {
+		return nil, err
+	}
 
-	return io.ReadAll(response.Body)
+	log.Printf("%v\n", response.Status)
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		return responseBody, fmt.Errorf("POST %s returned %s: %s", url, response.Status, responseBody)
+	}
+
+	return responseBody, nil
 }
 
 // InfluxDB will throw an error/ignore any submitted data with a timestamp older than the
 // retention period. Lets fix this by opening test files, modifying the timestamp and returning an io.Reader
 func readSmartDataFileFixTimestamp(daysToSubtract int, smartDataFilepath string) (io.Reader, error) {
+	return readSmartDataFile(daysToSubtract, smartDataFilepath, false)
+}
+
+func readSmartDataFileWithTrend(daysToSubtract int, smartDataFilepath string) (io.Reader, error) {
+	return readSmartDataFile(daysToSubtract, smartDataFilepath, true)
+}
+
+func readSmartDataFile(daysToSubtract int, smartDataFilepath string, addTrend bool) (io.Reader, error) {
 	metricsfile, err := os.Open(smartDataFilepath)
 	if err != nil {
 		return nil, err
@@ -90,7 +168,13 @@ func readSmartDataFileFixTimestamp(daysToSubtract int, smartDataFilepath string)
 	}
 
 	daysToSubtractInHours := time.Duration(-1 * 24 * daysToSubtract)
-	smartData.LocalTime.TimeT = time.Now().Add(daysToSubtractInHours * time.Hour).Unix()
+	timestamp := time.Now().Add(daysToSubtractInHours * time.Hour)
+	if addTrend {
+		timestamp = timestamp.Add(-12 * time.Hour)
+		smartData.Temperature.Current = 30 + int64((30-daysToSubtract)%7)
+		smartData.PowerOnTime.Hours += int64((30 - daysToSubtract) * 24)
+	}
+	smartData.LocalTime.TimeT = timestamp.Unix()
 	updatedSmartDataBytes, err := json.Marshal(smartData)
 
 	return bytes.NewReader(updatedSmartDataBytes), nil

--- a/webapp/frontend/package-lock.json
+++ b/webapp/frontend/package-lock.json
@@ -23,6 +23,7 @@
                 "@types/humanize-duration": "^3.27.4",
                 "highlight.js": "^11.11.1",
                 "humanize-duration": "^3.34.0",
+                "jspdf": "^3.0.4",
                 "lodash": "4.18.1",
                 "moment": "^2.30.1",
                 "ng-apexcharts": "~1.7.7",
@@ -2800,7 +2801,6 @@
             "version": "7.29.7",
             "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
             "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
@@ -4289,6 +4289,12 @@
                 "undici-types": "~5.26.4"
             }
         },
+        "node_modules/@types/pako": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
+            "integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==",
+            "license": "MIT"
+        },
         "node_modules/@types/parse-json": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
@@ -4300,6 +4306,13 @@
             "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
             "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
             "dev": true
+        },
+        "node_modules/@types/raf": {
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
+            "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
+            "license": "MIT",
+            "optional": true
         },
         "node_modules/@types/range-parser": {
             "version": "1.2.4",
@@ -4340,6 +4353,13 @@
             "dependencies": {
                 "@types/node": "*"
             }
+        },
+        "node_modules/@types/trusted-types": {
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+            "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+            "license": "MIT",
+            "optional": true
         },
         "node_modules/@types/ws": {
             "version": "8.18.1",
@@ -5027,6 +5047,16 @@
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
             "dev": true
         },
+        "node_modules/base64-arraybuffer": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+            "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+            "license": "MIT",
+            "optional": true,
+            "engines": {
+                "node": ">= 0.6.0"
+            }
+        },
         "node_modules/base64-js": {
             "version": "1.5.1",
             "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -5412,6 +5442,26 @@
                 }
             ],
             "license": "CC-BY-4.0"
+        },
+        "node_modules/canvg": {
+            "version": "3.0.11",
+            "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
+            "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@babel/runtime": "^7.12.5",
+                "@types/raf": "^3.4.0",
+                "core-js": "^3.8.3",
+                "raf": "^3.4.1",
+                "regenerator-runtime": "^0.13.7",
+                "rgbcolor": "^1.0.1",
+                "stackblur-canvas": "^2.0.0",
+                "svg-pathdata": "^6.0.3"
+            },
+            "engines": {
+                "node": ">=10.0.0"
+            }
         },
         "node_modules/chalk": {
             "version": "2.4.2",
@@ -5820,7 +5870,7 @@
             "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.20.3.tgz",
             "integrity": "sha512-vVl8j8ph6tRS3B8qir40H7yw7voy17xL0piAjlbBUsH7WIfzoedL/ZOr1OV9FyZQLWXsayOJyV4tnRyXR85/ag==",
             "deprecated": "core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.",
-            "dev": true,
+            "devOptional": true,
             "hasInstallScript": true,
             "funding": {
                 "type": "opencollective",
@@ -6052,6 +6102,16 @@
             },
             "peerDependencies": {
                 "postcss": "^8.4"
+            }
+        },
+        "node_modules/css-line-break": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+            "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "utrie": "^1.0.2"
             }
         },
         "node_modules/css-loader": {
@@ -6428,6 +6488,16 @@
             },
             "funding": {
                 "url": "https://github.com/fb55/domhandler?sponsor=1"
+            }
+        },
+        "node_modules/dompurify": {
+            "version": "3.4.13",
+            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+            "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
+            "license": "(MPL-2.0 OR Apache-2.0)",
+            "optional": true,
+            "optionalDependencies": {
+                "@types/trusted-types": "^2.0.7"
             }
         },
         "node_modules/domutils": {
@@ -7035,6 +7105,17 @@
             "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
             "dev": true
         },
+        "node_modules/fast-png": {
+            "version": "6.4.0",
+            "resolved": "https://registry.npmjs.org/fast-png/-/fast-png-6.4.0.tgz",
+            "integrity": "sha512-kAqZq1TlgBjZcLr5mcN6NP5Rv4V2f22z00c3g8vRrwkcqjerx7BEhPbOnWCPqaHUl2XWQBJQvOT/FQhdMT7X/Q==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/pako": "^2.0.3",
+                "iobuffer": "^5.3.2",
+                "pako": "^2.1.0"
+            }
+        },
         "node_modules/fast-uri": {
             "version": "3.1.4",
             "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
@@ -7090,6 +7171,12 @@
                     "optional": true
                 }
             }
+        },
+        "node_modules/fflate": {
+            "version": "0.8.3",
+            "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+            "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+            "license": "MIT"
         },
         "node_modules/figures": {
             "version": "3.2.0",
@@ -7676,6 +7763,20 @@
             "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
             "dev": true
         },
+        "node_modules/html2canvas": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+            "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "css-line-break": "^2.1.0",
+                "text-segmentation": "^1.0.3"
+            },
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
         "node_modules/http-cache-semantics": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
@@ -8071,6 +8172,12 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/iobuffer": {
+            "version": "5.4.0",
+            "resolved": "https://registry.npmjs.org/iobuffer/-/iobuffer-5.4.0.tgz",
+            "integrity": "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==",
+            "license": "MIT"
         },
         "node_modules/ip": {
             "version": "2.0.0",
@@ -8560,6 +8667,23 @@
             "engines": [
                 "node >= 0.2.0"
             ]
+        },
+        "node_modules/jspdf": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-3.0.4.tgz",
+            "integrity": "sha512-dc6oQ8y37rRcHn316s4ngz/nOjayLF/FFxBF4V9zamQKRqXxyiH1zagkCdktdWhtoQId5K20xt1lB90XzkB+hQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/runtime": "^7.28.4",
+                "fast-png": "^6.2.0",
+                "fflate": "^0.8.1"
+            },
+            "optionalDependencies": {
+                "canvg": "^3.0.11",
+                "core-js": "^3.6.0",
+                "dompurify": "^3.2.4",
+                "html2canvas": "^1.0.0-rc.5"
+            }
         },
         "node_modules/karma": {
             "version": "6.4.4",
@@ -10435,6 +10559,22 @@
                 "node": "^12.13.0 || ^14.15.0 || >=16"
             }
         },
+        "node_modules/pako": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/pako/-/pako-2.2.0.tgz",
+            "integrity": "sha512-zJq6RP/5q+TO2OpFV3FHzlPnFjmkb7Nc99a5SNjJE+uu/PkpChs+NIZSSzbBoD+6kjiISXjfYdwj1ZRQ81dz/w==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/puzrin"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/nodeca"
+                }
+            ],
+            "license": "(MIT AND Zlib)"
+        },
         "node_modules/parent-module": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -10589,6 +10729,13 @@
             "resolved": "https://registry.npmjs.org/perfect-scrollbar/-/perfect-scrollbar-1.5.6.tgz",
             "integrity": "sha512-rixgxw3SxyJbCaSpo1n35A/fwI1r2rdwMKOTCg/AcG+xOEyZcE8UHVjpZMFCVImzsFoCZeJTT+M/rdEIQYO2nw==",
             "license": "MIT"
+        },
+        "node_modules/performance-now": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+            "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+            "license": "MIT",
+            "optional": true
         },
         "node_modules/picocolors": {
             "version": "1.1.1",
@@ -11494,6 +11641,16 @@
                 }
             ]
         },
+        "node_modules/raf": {
+            "version": "3.4.1",
+            "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+            "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "performance-now": "^2.1.0"
+            }
+        },
         "node_modules/range-parser": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -11595,7 +11752,7 @@
             "version": "0.13.9",
             "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
             "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
-            "dev": true
+            "devOptional": true
         },
         "node_modules/regenerator-transform": {
             "version": "0.15.1",
@@ -11793,6 +11950,16 @@
             "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
             "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==",
             "dev": true
+        },
+        "node_modules/rgbcolor": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+            "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+            "license": "MIT OR SEE LICENSE IN FEEL-FREE.md",
+            "optional": true,
+            "engines": {
+                "node": ">= 0.8.15"
+            }
         },
         "node_modules/rimraf": {
             "version": "3.0.2",
@@ -12612,6 +12779,16 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/stackblur-canvas": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
+            "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
+            "license": "MIT",
+            "optional": true,
+            "engines": {
+                "node": ">=0.1.14"
+            }
+        },
         "node_modules/statuses": {
             "version": "1.5.0",
             "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
@@ -12804,6 +12981,16 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/svg-pathdata": {
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+            "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+            "license": "MIT",
+            "optional": true,
+            "engines": {
+                "node": ">=12.0.0"
             }
         },
         "node_modules/svg.draggable.js": {
@@ -13127,6 +13314,16 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/text-segmentation": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+            "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "utrie": "^1.0.2"
             }
         },
         "node_modules/text-table": {
@@ -13491,6 +13688,16 @@
             "dev": true,
             "engines": {
                 "node": ">= 0.4.0"
+            }
+        },
+        "node_modules/utrie": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+            "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "base64-arraybuffer": "^1.0.2"
             }
         },
         "node_modules/uuid": {

--- a/webapp/frontend/package.json
+++ b/webapp/frontend/package.json
@@ -32,6 +32,7 @@
         "@types/humanize-duration": "^3.27.4",
         "highlight.js": "^11.11.1",
         "humanize-duration": "^3.34.0",
+        "jspdf": "^3.0.4",
         "lodash": "4.18.1",
         "moment": "^2.30.1",
         "ng-apexcharts": "~1.7.7",

--- a/webapp/frontend/src/app/modules/dashboard/dashboard.component.html
+++ b/webapp/frontend/src/app/modules/dashboard/dashboard.component.html
@@ -18,11 +18,6 @@
                                   [svgIcon]="'archive'"></mat-icon>
                                 <span class="ml-2">Archived</span>
                     </button>
-                    <button matTooltip="not yet implemented" class="ml-2 xs:hidden" mat-stroked-button>
-                        <mat-icon class="icon-size-20"
-                                  [svgIcon]="'save'"></mat-icon>
-                        <span class="ml-2">Export</span>
-                    </button>
                     <button class="ml-2 xs:hidden"
                             (click)="openDialog()"
                             mat-stroked-button>
@@ -43,12 +38,6 @@
                                           [color]="showArchived ? 'primary' : null"
                                           [svgIcon]="'archive'"></mat-icon>
                                 <span class="ml-2">Archived</span>
-                            </button>
-                            <button mat-menu-item
-                                    matTooltip="not yet implemented">
-                                <mat-icon class="icon-size-20"
-                                          [svgIcon]="'save'"></mat-icon>
-                                <span class="ml-2">Export</span>
                             </button>
                             <button mat-menu-item (click)="openDialog()">
                                 <mat-icon class="icon-size-20 rotate-90 mirror"

--- a/webapp/frontend/src/app/modules/detail/detail-export.service.spec.ts
+++ b/webapp/frontend/src/app/modules/detail/detail-export.service.spec.ts
@@ -7,12 +7,14 @@ describe('DetailExportService', () => {
     it('downloads a one-page PDF containing the Scrutiny logo', async () => {
         const service = new DetailExportService();
         const logo = 'data:image/png;base64,logo';
+        const document = new jsPDF({unit: 'mm', format: 'a4'});
         spyOn<any>(service, 'loadLogo').and.resolveTo(logo);
-        const addImage = spyOn(jsPDF.prototype, 'addImage').and.callFake(() => jsPDF.prototype);
-        const setFillColor = spyOn(jsPDF.prototype, 'setFillColor').and.callFake(() => jsPDF.prototype);
-        const roundedRect = spyOn(jsPDF.prototype, 'roundedRect').and.callFake(() => jsPDF.prototype);
-        const text = spyOn(jsPDF.prototype, 'text').and.callFake(() => jsPDF.prototype);
-        const save = spyOn(jsPDF.prototype, 'save');
+        spyOn<any>(service, 'createDocument').and.returnValue(document);
+        const addImage = spyOn(document, 'addImage').and.callFake(() => document);
+        const setFillColor = spyOn(document, 'setFillColor').and.callThrough();
+        const roundedRect = spyOn(document, 'roundedRect').and.callThrough();
+        const text = spyOn(document, 'text').and.callThrough();
+        const save = spyOn(document, 'save');
 
         await service.exportLogoPdf({
             driveName: 'WDC WD140EDFZ-11A0VA0',
@@ -107,10 +109,12 @@ describe('DetailExportService', () => {
 
     it('uses protocol-specific columns for SCSI attributes', async () => {
         const service = new DetailExportService();
+        const document = new jsPDF({unit: 'mm', format: 'a4'});
         spyOn<any>(service, 'loadLogo').and.resolveTo('data:image/png;base64,logo');
-        const text = spyOn(jsPDF.prototype, 'text').and.callFake(() => jsPDF.prototype);
-        spyOn(jsPDF.prototype, 'addImage').and.callFake(() => jsPDF.prototype);
-        spyOn(jsPDF.prototype, 'save');
+        spyOn<any>(service, 'createDocument').and.returnValue(document);
+        const text = spyOn(document, 'text').and.callThrough();
+        spyOn(document, 'addImage').and.callFake(() => document);
+        spyOn(document, 'save');
 
         await service.exportLogoPdf({
             driveName: 'SCSI Drive',

--- a/webapp/frontend/src/app/modules/detail/detail-export.service.spec.ts
+++ b/webapp/frontend/src/app/modules/detail/detail-export.service.spec.ts
@@ -1,3 +1,5 @@
+/// <reference types="jasmine" />
+
 import {DetailExportService} from './detail-export.service';
 import {jsPDF} from 'jspdf';
 import {DeviceModel} from 'app/core/models/device-model';

--- a/webapp/frontend/src/app/modules/detail/detail-export.service.spec.ts
+++ b/webapp/frontend/src/app/modules/detail/detail-export.service.spec.ts
@@ -1,0 +1,158 @@
+import {DetailExportService} from './detail-export.service';
+import {jsPDF} from 'jspdf';
+import {DeviceModel} from 'app/core/models/device-model';
+import {SmartModel} from 'app/core/models/measurements/smart-model';
+
+describe('DetailExportService', () => {
+    it('downloads a one-page PDF containing the Scrutiny logo', async () => {
+        const service = new DetailExportService();
+        const logo = 'data:image/png;base64,logo';
+        spyOn<any>(service, 'loadLogo').and.resolveTo(logo);
+        const addImage = spyOn(jsPDF.prototype, 'addImage').and.callFake(() => jsPDF.prototype);
+        const setFillColor = spyOn(jsPDF.prototype, 'setFillColor').and.callFake(() => jsPDF.prototype);
+        const roundedRect = spyOn(jsPDF.prototype, 'roundedRect').and.callFake(() => jsPDF.prototype);
+        const text = spyOn(jsPDF.prototype, 'text').and.callFake(() => jsPDF.prototype);
+        const save = spyOn(jsPDF.prototype, 'save');
+
+        await service.exportLogoPdf({
+            driveName: 'WDC WD140EDFZ-11A0VA0',
+            driveTitle: '/dev/sdc - WDC WD140EDFZ-11A0VA0',
+            device: {
+                manufacturer: 'ATA',
+                model_name: 'WDC WD140EDFZ-11A0VA0',
+                serial_number: '9RK4XXXXX',
+                scrutiny_uuid: '42caca8a-9b95-5c75-b059-305771a2a193',
+                wwn: '0x5000cca264ec3183',
+                firmware: 'MS1OA650',
+                capacity: 14000519643136,
+                device_protocol: 'ATA',
+                device_status: 3,
+            } as DeviceModel,
+            latestSmart: {
+                power_cycle_count: 86,
+                power_on_hours: 61320,
+                temp: 25,
+                attrs: {
+                    '1': {
+                        attribute_id: 1,
+                        value: 100,
+                        thresh: 16,
+                        transformed_value: 0,
+                        status: 0,
+                        failure_rate: 0.01,
+                    },
+                    '5': {
+                        attribute_id: 5,
+                        value: 1975,
+                        thresh: 5,
+                        transformed_value: 0,
+                        status: 4,
+                        failure_rate: 1.5,
+                    },
+                },
+            } as unknown as SmartModel,
+            metadata: {
+                '1': {
+                    display_name: 'Read Error Rate',
+                    ideal: 'high',
+                    critical: false,
+                    description: '',
+                    display_type: 'normalized',
+                },
+                '5': {
+                    display_name: 'Reallocated Sectors Count',
+                    ideal: 'low',
+                    critical: true,
+                    description: '',
+                    display_type: 'raw',
+                },
+            },
+            config: {
+                file_size_si_units: false,
+                powered_on_hours_unit: 'humanize',
+                temperature_unit: 'celsius',
+                metrics: {status_threshold: 3},
+            },
+        },
+            new Date(2026, 7, 12, 3, 45),
+        );
+
+        expect(addImage.calls.mostRecent().args as unknown[]).toEqual([logo, 'PNG', 20, 20, 70, 10.85]);
+        expect(setFillColor).toHaveBeenCalledWith(81, 69, 205);
+        expect(roundedRect).toHaveBeenCalledWith(12, 10, 186, 277, 3, 3, 'F');
+        expect(text).toHaveBeenCalledWith('Drive Details - /dev/sdc - WDC WD140EDFZ-11A0VA0', 20, 57);
+        expect(text).toHaveBeenCalledWith('Dive into S.M.A.R.T data', 20, 64);
+        expect(text).toHaveBeenCalledWith('FAILED: BOTH', 22, 88);
+        expect(text).toHaveBeenCalledWith('Status', 20, 93);
+        expect(text).toHaveBeenCalledWith('ATA', 64, 88);
+        expect(text).toHaveBeenCalledWith('Model Family', 64, 93);
+        expect(text).toHaveBeenCalledWith('WDC WD140EDFZ-11A0VA0', 108, 88);
+        expect(text).toHaveBeenCalledWith('Device Model', 108, 93);
+        expect(text).toHaveBeenCalledWith('9RK4XXXXX', 152, 88);
+        expect(text).toHaveBeenCalledWith('Serial Number', 152, 93);
+        expect(text).toHaveBeenCalledWith('12.7 TiB', 108, 104);
+        expect(text).toHaveBeenCalledWith('Capacity', 108, 109);
+        expect(text.calls.allArgs().some(args => args[0] === 'Scrutiny UUID')).toBeFalse();
+        expect(text).toHaveBeenCalledWith('S.M.A.R.T ATA ATTRIBUTES', 20, 142);
+        expect(text).toHaveBeenCalledWith('Read Error Rate', 58, 156);
+        expect(text).toHaveBeenCalledWith('Reallocated Sectors Count', 58, 163);
+        expect(setFillColor).toHaveBeenCalledWith(188, 240, 218);
+        expect(roundedRect).toHaveBeenCalledWith(19, 152.3, 16, 4.8, 2.4, 2.4, 'F');
+        expect(text).toHaveBeenCalledWith('PASSED', 21.5, 155.6);
+        expect(text.calls.allArgs().some(args => args[0] === 'History')).toBeFalse();
+        expect(text.calls.allArgs().some(args => String(args[0]).includes('visible'))).toBeFalse();
+        expect(save).toHaveBeenCalledWith('2026-08-12-03-45-scrutiny-drive-report-WDC_WD140EDFZ-11A0VA0.pdf');
+        expect(addImage).toHaveBeenCalledTimes(1);
+    });
+
+    it('uses protocol-specific columns for SCSI attributes', async () => {
+        const service = new DetailExportService();
+        spyOn<any>(service, 'loadLogo').and.resolveTo('data:image/png;base64,logo');
+        const text = spyOn(jsPDF.prototype, 'text').and.callFake(() => jsPDF.prototype);
+        spyOn(jsPDF.prototype, 'addImage').and.callFake(() => jsPDF.prototype);
+        spyOn(jsPDF.prototype, 'save');
+
+        await service.exportLogoPdf({
+            driveName: 'SCSI Drive',
+            driveTitle: '/dev/sde - SCSI Drive',
+            device: {
+                manufacturer: 'SEAGATE',
+                model_name: 'SCSI Drive',
+                serial_number: 'serial',
+                scrutiny_uuid: 'uuid',
+                wwn: 'wwn',
+                firmware: '',
+                capacity: 1000,
+                device_protocol: 'SCSI',
+                device_status: 0,
+            } as DeviceModel,
+            latestSmart: {
+                attrs: {
+                    read_correction_algorithm_invocations: {
+                        attribute_id: 'read_correction_algorithm_invocations',
+                        value: 0,
+                        thresh: -1,
+                        transformed_value: 0,
+                        status: 0,
+                    },
+                },
+            } as unknown as SmartModel,
+            metadata: {
+                read_correction_algorithm_invocations: {
+                    display_name: 'Read Correction Algorithm Invocations',
+                    ideal: '',
+                    critical: false,
+                    description: '',
+                    display_type: 'raw',
+                },
+            },
+            config: {metrics: {status_threshold: 3}},
+        }, new Date(2026, 7, 12, 3, 45));
+
+        expect(text).toHaveBeenCalledWith('Name', 50, 149.5);
+        expect(text).toHaveBeenCalledWith('Read Correction Algorithm Invocations', 50, 156);
+        expect(text.calls.allArgs().some(args => args[0] === 'ID')).toBeFalse();
+        expect(text.calls.allArgs().some(args => args[0] === 'Ideal')).toBeFalse();
+        expect(text.calls.allArgs().some(args => args[0] === 'Failure Rate')).toBeFalse();
+    });
+});

--- a/webapp/frontend/src/app/modules/detail/detail-export.service.ts
+++ b/webapp/frontend/src/app/modules/detail/detail-export.service.ts
@@ -1,0 +1,263 @@
+import {Injectable} from '@angular/core';
+import {jsPDF} from 'jspdf';
+import {AppConfig, MetricsStatusThreshold} from 'app/core/config/app.config';
+import {DeviceModel} from 'app/core/models/device-model';
+import {SmartModel} from 'app/core/models/measurements/smart-model';
+import {DeviceHoursPipe} from 'app/shared/device-hours.pipe';
+import {DeviceStatusPipe} from 'app/shared/device-status.pipe';
+import {FileSizePipe} from 'app/shared/file-size.pipe';
+import {TemperaturePipe} from 'app/shared/temperature.pipe';
+import {AttributeMetadataModel} from 'app/core/models/thresholds/attribute-metadata-model';
+import {SmartAttributeModel} from 'app/core/models/measurements/smart-attribute-model';
+
+interface DriveReport {
+    driveName: string;
+    driveTitle: string;
+    device: DeviceModel;
+    latestSmart?: SmartModel;
+    metadata: { [key: string]: AttributeMetadataModel } | { [key: number]: AttributeMetadataModel };
+    config: AppConfig;
+}
+
+@Injectable({providedIn: 'root'})
+export class DetailExportService {
+    async exportLogoPdf(report: DriveReport, exportedAt: Date = new Date()): Promise<void> {
+        const logo = await this.loadLogo();
+        const document = new jsPDF({unit: 'mm', format: 'a4'});
+
+        // Mirror the web layout: a primary-color backdrop with a raised, rounded
+        // header container and the drive-details heading below the logo bar.
+        document.setFillColor(81, 69, 205);
+        document.rect(0, 0, 210, 28, 'F');
+        document.setFillColor(255, 255, 255);
+        document.roundedRect(12, 10, 186, 277, 3, 3, 'F');
+        document.addImage(logo, 'PNG', 20, 20, 70, 10.85);
+        document.setDrawColor(226, 232, 240);
+        document.line(12, 42, 198, 42);
+        document.setTextColor(36, 43, 56);
+        document.setFont('helvetica', 'bold');
+        document.setFontSize(18);
+        document.text(`Drive Details - ${report.driveTitle}`, 20, 57);
+        document.setTextColor(100, 116, 139);
+        document.setFont('helvetica', 'normal');
+        document.setFontSize(10);
+        document.text('Dive into S.M.A.R.T data', 20, 64);
+        document.line(20, 70, 190, 70);
+
+        this.drawDeviceSummary(document, report);
+        this.drawSmartAttributes(document, report);
+        document.save(this.buildFilename(report.driveName, exportedAt));
+    }
+
+    private drawSmartAttributes(document: jsPDF, report: DriveReport): void {
+        const attributes = Object.values(report.latestSmart?.attrs ?? {})
+            .sort((left, right) => Number(left.attribute_id) - Number(right.attribute_id));
+
+        document.setTextColor(100, 116, 139);
+        document.setFont('helvetica', 'bold');
+        document.setFontSize(10);
+        document.text(`S.M.A.R.T ${report.device.device_protocol} ATTRIBUTES`, 20, 142);
+
+        const isAta = report.device.device_protocol === 'ATA';
+        const isScsi = report.device.device_protocol === 'SCSI';
+        const columns = isAta
+            ? [
+                {key: 'status', label: 'Status', x: 20},
+                {key: 'id', label: 'ID', x: 42},
+                {key: 'name', label: 'Name', x: 58},
+                {key: 'value', label: 'Value', x: 120},
+                {key: 'threshold', label: 'Threshold', x: 139},
+                {key: 'ideal', label: 'Ideal', x: 161},
+                {key: 'failure', label: 'Failure Rate', x: 176},
+            ]
+            : isScsi
+                ? [
+                    {key: 'status', label: 'Status', x: 20},
+                    {key: 'name', label: 'Name', x: 50},
+                    {key: 'value', label: 'Value', x: 145},
+                    {key: 'threshold', label: 'Threshold', x: 170},
+                ]
+                : [
+                    {key: 'status', label: 'Status', x: 20},
+                    {key: 'name', label: 'Name', x: 50},
+                    {key: 'value', label: 'Value', x: 130},
+                    {key: 'threshold', label: 'Threshold', x: 151},
+                    {key: 'ideal', label: 'Ideal', x: 174},
+                ];
+        document.setFillColor(241, 245, 249);
+        document.rect(16, 145, 178, 7, 'F');
+        document.setFontSize(7);
+        columns.forEach(column => document.text(column.label, column.x, 149.5));
+
+        attributes.forEach((attribute, index) => {
+            const y = 156 + index * 7;
+            const metadata = report.metadata[attribute.attribute_id];
+            const status = this.attributeStatus(attribute.status);
+
+            document.setDrawColor(226, 232, 240);
+            document.line(16, y + 2.5, 194, y + 2.5);
+            document.setFont('helvetica', 'normal');
+            document.setFontSize(7);
+            columns.forEach(column => {
+                if (column.key === 'status') {
+                    this.drawStatusChip(document, status, status.toUpperCase(), column.x, y, true);
+                    return;
+                }
+                document.setTextColor(36, 43, 56);
+                document.text(this.attributeCell(column.key, attribute, metadata), column.x, y);
+            });
+        });
+    }
+
+    private attributeStatus(status: number): string {
+        // Keep these bit flags aligned with the status constants used by the details UI.
+        // tslint:disable-next-line:no-bitwise
+        if ((status & 5) !== 0) {
+            return 'failed';
+        }
+        // tslint:disable-next-line:no-bitwise
+        if ((status & 2) !== 0) {
+            return 'warn';
+        }
+        return 'passed';
+    }
+
+    private drawStatusChip(document: jsPDF, status: string, label: string, x: number, y: number, compact = false): void {
+        const palette = status === 'failed'
+            ? {background: [251, 213, 213], text: [155, 28, 28]}
+            : status === 'warn'
+                ? {background: [252, 233, 106], text: [114, 59, 19]}
+                : {background: [188, 240, 218], text: [3, 84, 63]};
+        document.setFont('helvetica', 'bold');
+        document.setFontSize(7);
+        const standardWidths = compact
+            ? {PASSED: 16, FAILED: 16, WARN: 14}
+            : {PASSED: 18, FAILED: 18, WARN: 16};
+        const horizontalPadding = compact ? 4 : 6;
+        const minimumWidth = compact ? 14 : 16;
+        const width = standardWidths[label] ?? Math.max(minimumWidth, document.getTextWidth(label) + horizontalPadding);
+        const height = compact ? 4.8 : 6;
+        const radius = height / 2;
+        const top = compact ? y - 3.7 : y - 4.5;
+        const textX = compact ? x + 1.5 : x + 2;
+        const textY = compact ? y - 0.4 : y - 0.5;
+
+        document.setFillColor(...palette.background as [number, number, number]);
+        document.roundedRect(x - 1, top, width, height, radius, radius, 'F');
+        document.setTextColor(...palette.text as [number, number, number]);
+        document.text(label, textX, textY);
+    }
+
+    private attributeCell(key: string, attribute: SmartAttributeModel, metadata?: AttributeMetadataModel): string {
+        switch (key) {
+            case 'id':
+                return `${attribute.attribute_id} (0x${Number(attribute.attribute_id).toString(16).toUpperCase().padStart(2, '0')})`;
+            case 'name':
+                return metadata?.display_name ?? 'Unknown Attribute Name';
+            case 'value':
+                return String(this.attributeValue(attribute, metadata));
+            case 'threshold':
+                return attribute.thresh === -1 ? '' : String(attribute.thresh ?? '');
+            case 'ideal':
+                return metadata?.display_type === 'raw' ? metadata.ideal ?? '' : '';
+            case 'failure':
+                return attribute.failure_rate == null ? '' : `${Math.round(attribute.failure_rate * 100)}%`;
+            default:
+                return '';
+        }
+    }
+
+    private attributeValue(attribute: SmartAttributeModel, metadata?: AttributeMetadataModel): number {
+        if (metadata?.display_type === 'raw') {
+            return attribute.raw_value ?? attribute.value;
+        }
+        if (metadata?.display_type === 'transformed' && attribute.transformed_value) {
+            return attribute.transformed_value;
+        }
+        return attribute.value;
+    }
+
+    private drawDeviceSummary(document: jsPDF, report: DriveReport): void {
+        const smart = report.latestSmart;
+        const status = DeviceStatusPipe.deviceStatusForModelWithThreshold(
+            report.device,
+            !!smart,
+            report.config.metrics?.status_threshold ?? MetricsStatusThreshold.Both,
+            true,
+        ).toUpperCase();
+        const fields = [
+            {label: 'Status', value: status},
+            {label: 'Model Family', value: report.device.manufacturer},
+            {label: 'Device Model', value: report.device.model_name},
+            {label: 'Serial Number', value: report.device.serial_number},
+            {label: 'LU WWN Device Id', value: report.device.wwn},
+            {label: 'Firmware Version', value: report.device.firmware},
+            {label: 'Capacity', value: new FileSizePipe().transform(report.device.capacity, report.config.file_size_si_units)},
+            {label: 'Protocol', value: report.device.device_protocol},
+            {label: 'Power Cycle Count', value: smart?.power_cycle_count ?? 'Unknown'},
+            {
+                label: 'Powered On',
+                value: smart
+                    ? DeviceHoursPipe.format(smart.power_on_hours, report.config.powered_on_hours_unit, {
+                        round: true,
+                        largest: 1,
+                        units: ['y', 'd', 'h'],
+                    })
+                    : 'Unknown',
+            },
+            {
+                label: 'Temperature',
+                value: smart
+                    ? new TemperaturePipe().transform(smart.temp, report.config.temperature_unit, true)
+                    : 'Unknown',
+            },
+        ];
+        const columnX = [20, 64, 108, 152];
+
+        fields.forEach((field, index) => {
+            const x = columnX[index % 4];
+            const y = 88 + Math.floor(index / 4) * 16;
+            if (field.label === 'Status') {
+                this.drawStatusChip(document, status.includes('FAILED') ? 'failed' : 'passed', status, x, y + 0.5);
+            } else {
+                document.setTextColor(36, 43, 56);
+                document.setFont('helvetica', 'bold');
+                document.setFontSize(9);
+                document.text(String(field.value), x, y);
+            }
+            document.setTextColor(100, 116, 139);
+            document.setFont('helvetica', 'normal');
+            document.setFontSize(8);
+            document.text(field.label, x, y + 5);
+        });
+    }
+
+    private buildFilename(driveName: string, exportedAt: Date): string {
+        const pad = (value: number): string => value.toString().padStart(2, '0');
+        const timestamp = [
+            exportedAt.getFullYear(),
+            pad(exportedAt.getMonth() + 1),
+            pad(exportedAt.getDate()),
+            pad(exportedAt.getHours()),
+            pad(exportedAt.getMinutes()),
+        ].join('-');
+        const safeDriveName = driveName.trim().replace(/\s+/g, '_');
+
+        return `${timestamp}-scrutiny-drive-report-${safeDriveName}.pdf`;
+    }
+
+    private async loadLogo(): Promise<string> {
+        const response = await fetch('assets/images/logo/scrutiny-logo-dark-text.png');
+        if (!response.ok) {
+            throw new Error(`Unable to load Scrutiny logo: ${response.status}`);
+        }
+
+        const blob = await response.blob();
+        return new Promise<string>((resolve, reject) => {
+            const reader = new FileReader();
+            reader.onload = () => resolve(reader.result as string);
+            reader.onerror = () => reject(reader.error);
+            reader.readAsDataURL(blob);
+        });
+    }
+}

--- a/webapp/frontend/src/app/modules/detail/detail-export.service.ts
+++ b/webapp/frontend/src/app/modules/detail/detail-export.service.ts
@@ -23,7 +23,7 @@ interface DriveReport {
 export class DetailExportService {
     async exportLogoPdf(report: DriveReport, exportedAt: Date = new Date()): Promise<void> {
         const logo = await this.loadLogo();
-        const document = new jsPDF({unit: 'mm', format: 'a4'});
+        const document = this.createDocument();
 
         // Mirror the web layout: a primary-color backdrop with a raised, rounded
         // header container and the drive-details heading below the logo bar.
@@ -47,6 +47,10 @@ export class DetailExportService {
         this.drawDeviceSummary(document, report);
         this.drawSmartAttributes(document, report);
         document.save(this.buildFilename(report.driveName, exportedAt));
+    }
+
+    private createDocument(): jsPDF {
+        return new jsPDF({unit: 'mm', format: 'a4'});
     }
 
     private drawSmartAttributes(document: jsPDF, report: DriveReport): void {

--- a/webapp/frontend/src/app/modules/detail/detail.component.html
+++ b/webapp/frontend/src/app/modules/detail/detail.component.html
@@ -10,7 +10,7 @@
             <!-- Action buttons -->
             <div class="flex items-center">
                 <button class="xs:hidden"
-                        matTooltip="not yet implemented"
+                        (click)="exportPdf()"
                         mat-stroked-button>
                     <mat-icon class="icon-size-20"
                               [svgIcon]="'save'"></mat-icon>
@@ -32,7 +32,7 @@
                     </button>
                     <mat-menu #actionsMenu="matMenu">
                         <button mat-menu-item
-                                matTooltip="not yet implemented">
+                                (click)="exportPdf()">
                             <mat-icon class="icon-size-20"
                                       [svgIcon]="'save'"></mat-icon>
                             <span class="ml-2">Export</span>

--- a/webapp/frontend/src/app/modules/detail/detail.component.ts
+++ b/webapp/frontend/src/app/modules/detail/detail.component.ts
@@ -17,6 +17,7 @@ import {SmartModel} from 'app/core/models/measurements/smart-model';
 import {SmartAttributeModel} from 'app/core/models/measurements/smart-attribute-model';
 import {AttributeMetadataModel} from 'app/core/models/thresholds/attribute-metadata-model';
 import {DeviceStatusPipe} from 'app/shared/device-status.pipe';
+import {DetailExportService} from './detail-export.service';
 
 // from Constants.go - these must match
 const AttributeStatusPassed = 0
@@ -50,6 +51,7 @@ export class DetailComponent implements OnInit, AfterViewInit, OnDestroy {
      */
     constructor(
         private _detailService: DetailService,
+        private _detailExportService: DetailExportService,
         public dialog: MatDialog,
         private _configService: ScrutinyConfigService,
         @Inject(LOCALE_ID) public locale: string
@@ -89,6 +91,22 @@ export class DetailComponent implements OnInit, AfterViewInit, OnDestroy {
     private systemPrefersDark: boolean;
 
     readonly humanizeDuration = humanizeDuration;
+
+    exportPdf(): void {
+        const deviceName = this.device.device_name.startsWith('/dev/')
+            ? this.device.device_name
+            : `/dev/${this.device.device_name}`;
+        void this._detailExportService.exportLogoPdf(
+            {
+                driveName: this.device.model_name,
+                driveTitle: `${deviceName} - ${this.device.model_name}`,
+                device: this.device,
+                latestSmart: this.smart_results[0],
+                metadata: this.metadata,
+                config: this.config,
+            },
+        );
+    }
 
     deviceStatusForModelWithThreshold = DeviceStatusPipe.deviceStatusForModelWithThreshold
     // -----------------------------------------------------------------------------------------------------


### PR DESCRIPTION
# Implement per-drive PDF export reports

## Summary

This PR implements the previously non-functional **Export** button on the drive details page.

There is no associated issue or documented specification. Since the UI exposed the action with a “not yet implemented” tooltip, I interpreted Export as a human-readable drive report similar to CrystalDiskInfo—useful for troubleshooting, documentation, or selling a drive.

## Report contents

The browser-generated PDF includes:

- Scrutiny branding
- Drive identity, hardware details, and overall health
- Capacity, temperature, power-on time, and power cycles
- All latest SMART attributes
- Protocol-specific ATA, NVMe, and SCSI layouts
- Printable Passed, Warn, and Failed status chips
- A sortable timestamp and drive name in the filename

PDF generation uses jsPDF and requires no new backend endpoint.

## Dashboard Export button

This PR removes Export from the dashboard because I could not identify a useful dashboard-wide report. This is debatable, and I am happy to restore it if maintainers have another intended use.

## Development support

The PR also adds a **Run Scrutiny with Dummy Data** VS Code configuration and fixes the existing helper to use Scrutiny UUIDs, wait for the API, load richer sample history, verify successful loading, and report rejected requests.

## Testing

Focused red/green tests cover PDF generation, naming, layout, complete SMART data, printable status chips, and protocol-specific tables.

Verified with `npx tsc --project tsconfig.spec.json --noEmit`.

The Karma bundle compiles, but browser execution was unavailable because the development container lacks a working Chrome/Chromium binary.

## Design note

Repository history does not clarify whether Export was intended as PDF, CSV, or JSON. PDF was chosen as a portable report, but feedback on the format, fields, and dashboard decision is welcome.

## AI assistance disclosure

This PR was developed with assistance from OpenAI Codex. The implementation, tests, history review, and PR description were produced collaboratively and reviewed interactively by the contributor.