### PR TITLE
feat(web): export self-contained HTML drive reports

### DIFF
--- a/.devcontainer/docker/devcontainer-lock.json
+++ b/.devcontainer/docker/devcontainer-lock.json
@@ -1,0 +1,14 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/go:1": {
+      "version": "1.3.4",
+      "resolved": "ghcr.io/devcontainers/features/go@sha256:d85e921f91b41340055bb12b325d9d551170ed04b3b832e33530bf42f167c032",
+      "integrity": "sha256:d85e921f91b41340055bb12b325d9d551170ed04b3b832e33530bf42f167c032"
+    },
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "1.7.1",
+      "resolved": "ghcr.io/devcontainers/features/node@sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6",
+      "integrity": "sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6"
+    }
+  }
+}

--- a/webapp/frontend/src/app/modules/detail/detail-html-export.service.spec.ts
+++ b/webapp/frontend/src/app/modules/detail/detail-html-export.service.spec.ts
@@ -1,0 +1,85 @@
+/// <reference types="jasmine" />
+
+import {DetailHtmlExportService} from './detail-html-export.service';
+
+describe('DetailHtmlExportService', () => {
+    let service: DetailHtmlExportService;
+
+    beforeEach(() => {
+        service = new DetailHtmlExportService(document);
+    });
+
+    it('builds a self-contained, non-interactive HTML report from rendered content', () => {
+        const source = document.createElement('section');
+        source.innerHTML = `
+            <h1>Drive Details - /dev/sda</h1>
+            <img src="https://example.com/external.png" alt="external">
+            <button data-report-exclude>Export</button>
+            <script>window.reportScriptRan = true;</script>
+            <link rel="stylesheet" href="https://example.com/report.css">
+            <div data-report-table style="width: 1000px; min-width: 1000px; height: 800px; min-height: 800px">
+                <div style="width: 1000px; height: 800px">
+                    <table style="width: 1000px; height: 800px" height="800">
+                        <tbody style="width: 1000px; height: 800px">
+                            <tr style="width: 1000px; height: 50px"><td style="width: 200px; height: 50px">PASSED</td></tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        `;
+        source.style.color = 'rgb(36, 43, 56)';
+        document.body.appendChild(source);
+
+        const html = service.buildReport(source, {
+            title: 'Drive Details - /dev/sda',
+            logoDataUrl: 'data:image/png;base64,c2NydXRpbnk=',
+        });
+
+        expect(html).toContain('<!doctype html>');
+        expect(html).toContain('<style>');
+        expect(html).toContain('Drive Details - /dev/sda');
+        expect(html).toContain('data:image/png;base64,c2NydXRpbnk=');
+        expect(html).toContain('PASSED');
+        expect(html).not.toContain('<script');
+        expect(html).not.toContain('<link');
+        expect(html).not.toContain('<button');
+        expect(html).not.toContain('https://example.com');
+        expect(html).not.toContain('window.reportScriptRan');
+        expect(html).toContain('[data-report-root], [data-report-layout] { display: block; width: 100%; }');
+
+        const exportedDocument = new DOMParser().parseFromString(html, 'text/html');
+        expect(exportedDocument.querySelector('.scrutiny-report__content [style]')).toBeNull();
+        exportedDocument.querySelectorAll<HTMLElement>('[data-report-table], [data-report-table] *')
+            .forEach(element => {
+                expect(element.style.width).toBe('');
+                expect(element.style.minWidth).toBe('');
+                expect(element.style.maxWidth).toBe('');
+                expect(element.style.height).toBe('');
+                expect(element.style.minHeight).toBe('');
+                expect(element.style.maxHeight).toBe('');
+                expect(element.hasAttribute('height')).toBeFalse();
+            });
+        expect(html).toContain('th, td { padding: 8px 10px;');
+        expect(html).toContain('[data-report-summary] treo-card > div { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr));');
+        expect(html).toContain('[data-report-table] { width: 100%; }');
+        expect(html).toContain('break-inside: avoid; page-break-inside: avoid;');
+
+        source.remove();
+    });
+
+    it('downloads the report with a sortable timestamp and sanitized drive name', () => {
+        const source = document.createElement('section');
+        source.textContent = 'report';
+        const download = spyOn<any>(service, 'downloadHtml');
+        spyOn<any>(service, 'loadLogo').and.resolveTo('data:image/png;base64,c2NydXRpbnk=');
+
+        service.exportReport(source, 'WDC WD140EDFZ-11A0VA0', 'Drive Details', new Date(2026, 7, 18, 3, 45));
+
+        return Promise.resolve().then(() => {
+            expect(download).toHaveBeenCalled();
+            expect(download.calls.mostRecent().args[1]).toBe(
+                '2026-08-18-03-45-scrutiny-drive-report-WDC_WD140EDFZ-11A0VA0.html',
+            );
+        });
+    });
+});

--- a/webapp/frontend/src/app/modules/detail/detail-html-export.service.ts
+++ b/webapp/frontend/src/app/modules/detail/detail-html-export.service.ts
@@ -1,0 +1,211 @@
+import {DOCUMENT} from '@angular/common';
+import {Inject, Injectable} from '@angular/core';
+
+interface HtmlReportOptions {
+    title: string;
+    logoDataUrl: string;
+}
+
+@Injectable({providedIn: 'root'})
+export class DetailHtmlExportService {
+    constructor(@Inject(DOCUMENT) private readonly document: Document) {
+    }
+
+    async exportReport(
+        source: HTMLElement,
+        driveName: string,
+        title: string,
+        exportedAt: Date = new Date(),
+    ): Promise<void> {
+        const logoDataUrl = await this.loadLogo();
+        const html = this.buildReport(source, {title, logoDataUrl});
+        this.downloadHtml(html, this.buildFilename(driveName, exportedAt));
+    }
+
+    buildReport(source: HTMLElement, options: HtmlReportOptions): string {
+        const reportContent = source.cloneNode(true) as HTMLElement;
+        this.removeInteractiveAndExternalContent(reportContent);
+        this.stripApplicationPresentation(reportContent);
+
+        return `<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>${this.escapeHtml(options.title)}</title>
+    <style>${this.reportStyles()}</style>
+</head>
+<body>
+    <main class="scrutiny-report">
+        <header class="scrutiny-report__header">
+            <img src="${options.logoDataUrl}" alt="Scrutiny">
+        </header>
+        <div class="scrutiny-report__content">${reportContent.outerHTML}</div>
+    </main>
+</body>
+</html>`;
+    }
+
+    private removeInteractiveAndExternalContent(reportContent: HTMLElement): void {
+        reportContent.querySelectorAll(
+            'script, link, iframe, object, embed, mat-icon, [data-report-exclude], .mat-tooltip',
+        ).forEach(element => element.remove());
+
+        reportContent.querySelectorAll('*').forEach(element => {
+            Array.from(element.attributes).forEach(attribute => {
+                if (attribute.name.startsWith('on')) {
+                    element.removeAttribute(attribute.name);
+                }
+            });
+
+            ['src', 'href', 'poster'].forEach(attributeName => {
+                const value = element.getAttribute(attributeName);
+                if (value && !value.startsWith('data:') && !value.startsWith('#')) {
+                    element.removeAttribute(attributeName);
+                }
+            });
+        });
+    }
+
+    private stripApplicationPresentation(reportContent: HTMLElement): void {
+        [reportContent, ...Array.from(reportContent.querySelectorAll<HTMLElement>('*'))]
+            .forEach(element => {
+                Array.from(element.attributes).forEach(attribute => {
+                    if (attribute.name === 'style' ||
+                        attribute.name === 'width' ||
+                        attribute.name === 'height' ||
+                        attribute.name.startsWith('_ngcontent-') ||
+                        attribute.name.startsWith('_nghost-') ||
+                        attribute.name.startsWith('ng-reflect-')) {
+                        element.removeAttribute(attribute.name);
+                    }
+                });
+            });
+    }
+
+    private async loadLogo(): Promise<string> {
+        const response = await fetch('assets/images/logo/scrutiny-logo-dark-text.png');
+        if (!response.ok) {
+            throw new Error(`Unable to load Scrutiny logo: ${response.status}`);
+        }
+        const blob = await response.blob();
+        return new Promise<string>((resolve, reject) => {
+            const reader = new FileReader();
+            reader.onload = () => resolve(String(reader.result));
+            reader.onerror = () => reject(reader.error);
+            reader.readAsDataURL(blob);
+        });
+    }
+
+    private downloadHtml(html: string, filename: string): void {
+        const blob = new Blob([html], {type: 'text/html;charset=utf-8'});
+        const url = URL.createObjectURL(blob);
+        const anchor = this.document.createElement('a');
+        anchor.href = url;
+        anchor.download = filename;
+        anchor.click();
+        URL.revokeObjectURL(url);
+    }
+
+    private buildFilename(driveName: string, exportedAt: Date): string {
+        const pad = (value: number): string => value.toString().padStart(2, '0');
+        const timestamp = [
+            exportedAt.getFullYear(),
+            pad(exportedAt.getMonth() + 1),
+            pad(exportedAt.getDate()),
+            pad(exportedAt.getHours()),
+            pad(exportedAt.getMinutes()),
+        ].join('-');
+        const sanitizedDriveName = driveName.trim()
+            .replace(/\s+/g, '_')
+            .replace(/[^A-Za-z0-9._-]/g, '_');
+        return `${timestamp}-scrutiny-drive-report-${sanitizedDriveName}.html`;
+    }
+
+    private escapeHtml(value: string): string {
+        return value
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#039;');
+    }
+
+    private reportStyles(): string {
+        return `
+            :root { color-scheme: light; }
+            * { box-sizing: border-box; }
+            body { margin: 0; background: #5145cd; color: #242b38; font-family: Arial, Helvetica, sans-serif; }
+            .scrutiny-report { width: min(1200px, calc(100% - 48px)); margin: 24px auto; background: #fff; border-radius: 12px; overflow: hidden; }
+            .scrutiny-report__header { min-height: 96px; display: flex; align-items: center; padding: 24px 40px; border-bottom: 1px solid #e2e8f0; }
+            .scrutiny-report__header img { display: block; width: 180px; height: auto; }
+            .scrutiny-report__content { padding: 24px 40px 40px; }
+            .scrutiny-report [data-report-exclude] { display: none !important; }
+            [data-report-root], [data-report-layout] { display: block; width: 100%; }
+            [data-report-heading] { width: 100%; margin: 4px 0 24px; }
+            [data-report-heading] h2 { margin: 0; font-size: 28px; line-height: 1.2; }
+            [data-report-heading] .text-secondary { margin-top: 4px; color: #64748b; }
+            [data-report-summary] { width: 100%; margin-bottom: 28px; }
+            [data-report-summary] treo-card { display: block; padding: 18px 20px; border: 1px solid #e2e8f0; border-radius: 8px; }
+            [data-report-summary] treo-card > div { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 16px 24px; }
+            [data-report-summary] treo-card > div > div { min-width: 0; overflow-wrap: anywhere; }
+            [data-report-summary] treo-card > div > div > div:first-child { font-weight: 600; }
+            [data-report-summary] .text-secondary { margin-top: 2px; color: #64748b; font-size: 12px; font-weight: 400; }
+            [data-report-table] { width: 100%; }
+            [data-report-table] > div { width: 100%; border: 1px solid #e2e8f0; border-radius: 8px; overflow: hidden; }
+            [data-report-table] .p-6 { padding: 16px 20px; }
+            [data-report-table] .font-bold { font-weight: 700; }
+            [data-report-table] .uppercase { text-transform: uppercase; }
+            [data-report-table] .tracking-wider { letter-spacing: .04em; }
+            table { width: 100%; border-collapse: collapse; table-layout: auto; }
+            thead { display: table-header-group; }
+            tbody { display: table-row-group; }
+            tfoot { display: table-footer-group; }
+            tr { display: table-row; }
+            th, td { padding: 8px 10px; border-bottom: 1px solid #e2e8f0; text-align: left; vertical-align: middle; line-height: 1.25; }
+            th { background: #f8fafc; color: #64748b; font-size: 12px; font-weight: 700; white-space: nowrap; }
+            td { color: #242b38; font-size: 13px; }
+            .mat-column-status { width: 92px; }
+            .mat-column-id { width: 105px; white-space: nowrap; }
+            .mat-column-value, .mat-column-thresh, .mat-column-ideal, .mat-column-failure { width: 86px; white-space: nowrap; }
+            .mat-column-status > span,
+            [data-report-summary] .inline-flex { display: inline-flex; align-items: center; padding: 2px 8px; border-radius: 999px; font-size: 11px; font-weight: 700; line-height: 1.3; text-transform: uppercase; white-space: nowrap; }
+            .mat-column-status > span > span:first-child,
+            [data-report-summary] .inline-flex > span:first-child { width: 7px; height: 7px; margin-right: 6px; border-radius: 50%; flex: 0 0 auto; }
+            .green-200 { background: #bcf0da; color: #03543f; }
+            .red-200 { background: #fbd5d5; color: #9b1c1c; }
+            .yellow-200 { background: #fce96a; color: #713f12; }
+            .bg-green { background: #0e9f6e; }
+            .bg-red { background: #f05252; }
+            .bg-yellow { background: #d69e2e; }
+            .yellow-50 { background: #fdfdea; }
+            @media (max-width: 800px) {
+                .scrutiny-report { width: min(100% - 24px, 1200px); margin: 12px auto; }
+                .scrutiny-report__content { padding: 20px; }
+                [data-report-summary] treo-card > div { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+            }
+            @media (max-width: 520px) {
+                [data-report-summary] treo-card > div { grid-template-columns: 1fr; }
+            }
+            @media print {
+                @page { size: A4 landscape; margin: 10mm; }
+                body { background: #fff; print-color-adjust: exact; -webkit-print-color-adjust: exact; }
+                .scrutiny-report { width: 100%; margin: 0; border-radius: 0; overflow: visible; }
+                .scrutiny-report__header { min-height: 0; padding: 4mm 0; }
+                .scrutiny-report__header img { width: 42mm; }
+                .scrutiny-report__content { padding: 4mm 0 0; }
+                [data-report-heading] { margin: 0 0 5mm; }
+                [data-report-heading] h2 { font-size: 20px; }
+                [data-report-summary] { margin-bottom: 5mm; break-inside: avoid; page-break-inside: avoid; }
+                [data-report-summary] treo-card { padding: 3mm 4mm; }
+                [data-report-summary] treo-card > div { grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 2.5mm 5mm; }
+                [data-report-table], [data-report-table] > div { overflow: visible; border-radius: 0; }
+                [data-report-table] .p-6 { padding: 2mm 0; }
+                thead { display: table-header-group; }
+                tfoot { display: table-footer-group; }
+                tr { break-inside: avoid; page-break-inside: avoid; }
+                th, td { padding: 1.2mm 1.5mm; font-size: 9px; }
+            }
+        `;
+    }
+}

--- a/webapp/frontend/src/app/modules/detail/detail.component.html
+++ b/webapp/frontend/src/app/modules/detail/detail.component.html
@@ -1,16 +1,16 @@
-<div class="flex flex-col flex-auto w-full p-8 xs:p-2">
+<div #reportContent data-report-root class="flex flex-col flex-auto w-full p-8 xs:p-2">
 
-    <div class="flex flex-wrap w-full">
+    <div class="flex flex-wrap w-full" data-report-layout>
 
-        <div class="flex items-center justify-between w-full my-4 px-4 xs:pr-0">
+        <div class="flex items-center justify-between w-full my-4 px-4 xs:pr-0" data-report-heading>
             <div class="mr-6">
                 <h2 class="m-0">Drive Details - {{device | deviceTitle:config.dashboard_display}} </h2>
                 <div class="text-secondary tracking-tight">Dive into S.M.A.R.T data</div>
             </div>
             <!-- Action buttons -->
-            <div class="flex items-center">
+            <div class="flex items-center" data-report-exclude>
                 <button class="xs:hidden"
-                        matTooltip="not yet implemented"
+                        (click)="exportHtmlReport()"
                         mat-stroked-button>
                     <mat-icon class="icon-size-20"
                               [svgIcon]="'save'"></mat-icon>
@@ -32,7 +32,7 @@
                     </button>
                     <mat-menu #actionsMenu="matMenu">
                         <button mat-menu-item
-                                matTooltip="not yet implemented">
+                                (click)="exportHtmlReport()">
                             <mat-icon class="icon-size-20"
                                       [svgIcon]="'save'"></mat-icon>
                             <span class="ml-2">Export</span>
@@ -50,7 +50,7 @@
 
 
         <!-- Card -->
-        <div class="flex flex-auto w-1/4 p-4 lt-md:w-full">
+        <div class="flex flex-auto w-1/4 p-4 lt-md:w-full" data-report-summary>
             <treo-card class="flex flex-auto p-4 flex-col flex-auto filter-list">
                 <div class="flex flex-col grid grid-cols-2">
                     <div *ngIf="device" class="my-2 col-span-2 lt-md:col-span-1">
@@ -138,11 +138,11 @@
             </treo-card>
         </div>
         <!-- S.M.A.R.T. Data table -->
-        <div class="flex flex-auto w-3/4 p-4 lt-md:w-full">
+        <div class="flex flex-auto w-3/4 p-4 lt-md:w-full" data-report-table>
             <div class="flex flex-col flex-auto w-full bg-card shadow-md rounded ">
                 <div class="p-6">
                     <div class="font-bold text-md text-secondary uppercase tracking-wider">S.M.A.R.T {{device?.device_protocol}} Attributes</div>
-                    <div class="text-sm text-hint font-medium">{{this.smartAttributeDataSource.data.length}} visible, {{getHiddenAttributes()}} hidden</div>
+                    <div class="text-sm text-hint font-medium" data-report-exclude>{{this.smartAttributeDataSource.data.length}} visible, {{getHiddenAttributes()}} hidden</div>
                 </div>
                 <div class="overflow-auto">
                     <table class="w-full bg-transparent"
@@ -308,6 +308,7 @@
                         <!-- History -->
                         <ng-container matColumnDef="history">
                             <th class="bg-cool-gray-50 dark:bg-cool-gray-700 border-t"
+                                data-report-exclude
                                 mat-header-cell
                                 mat-sort-header
                                 *matHeaderCellDef>
@@ -316,6 +317,7 @@
                                 </span>
                             </th>
                             <td mat-cell
+                                data-report-exclude
                                 *matCellDef="let attribute">
 
                                 <span class="font-medium whitespace-no-wrap">
@@ -419,8 +421,9 @@
                             [class.attribute-expanded-row]="expandedAttribute === row"
                             (click)="expandedAttribute = expandedAttribute === row ? null : row"
                             *matRowDef="let row; columns: smartAttributeTableColumns;"></tr>
-                        <tr mat-row *matRowDef="let row; columns: ['expandedDetail']" class="attribute-detail-row"></tr>
+                        <tr mat-row *matRowDef="let row; columns: ['expandedDetail']" class="attribute-detail-row" data-report-exclude></tr>
                         <tr class="h-16"
+                            data-report-exclude
                             mat-footer-row
                             *matFooterRowDef="['recentOrdersTableFooter']"></tr>
                     </table>

--- a/webapp/frontend/src/app/modules/detail/detail.component.spec.ts
+++ b/webapp/frontend/src/app/modules/detail/detail.component.spec.ts
@@ -1,0 +1,57 @@
+/// <reference types="jasmine" />
+
+import {ChangeDetectorRef, ElementRef} from '@angular/core';
+import {DetailComponent} from './detail.component';
+import {DetailHtmlExportService} from './detail-html-export.service';
+
+describe('DetailComponent HTML export', () => {
+    it('exports all attributes and restores the critical-only view', async () => {
+        const exportService = jasmine.createSpyObj<DetailHtmlExportService>('DetailHtmlExportService', ['exportReport']);
+        let exportedAttributeCount = 0;
+        exportService.exportReport.and.callFake(() => {
+            exportedAttributeCount = component.smartAttributeDataSource.data.length;
+            return Promise.resolve();
+        });
+        const changeDetector = jasmine.createSpyObj<ChangeDetectorRef>('ChangeDetectorRef', ['detectChanges']);
+        const component = new DetailComponent(
+            {} as any,
+            {} as any,
+            {} as any,
+            'en-US',
+            changeDetector,
+            exportService,
+        );
+        const reportElement = document.createElement('div');
+        component.reportContent = new ElementRef(reportElement);
+        component.device = {
+            device_name: 'sda',
+            model_name: 'Test Drive',
+            device_protocol: 'ATA',
+            device_status: 0,
+        } as any;
+        component.config = {dashboard_display: 'name'} as any;
+        component.metadata = {
+            1: {display_name: 'Critical', critical: true},
+            2: {display_name: 'Informational', critical: false},
+        } as any;
+        component.smart_results = [{
+            attrs: {
+                1: {attribute_id: 1, value: 100, thresh: 1, status: 0, chartData: []},
+                2: {attribute_id: 2, value: 100, thresh: 1, status: 0, chartData: []},
+            },
+        }] as any;
+        component.smartAttributeDataSource.data = [component.smart_results[0].attrs[1]];
+
+        await component.exportHtmlReport();
+
+        expect(exportedAttributeCount).toBe(2);
+        expect(exportService.exportReport).toHaveBeenCalledWith(
+            reportElement,
+            'Test Drive',
+            'Drive Details - /dev/sda - Test Drive',
+        );
+        expect(component.onlyCritical).toBeTrue();
+        expect(component.smartAttributeDataSource.data.length).toBe(1);
+        expect(changeDetector.detectChanges).toHaveBeenCalledTimes(2);
+    });
+});

--- a/webapp/frontend/src/app/modules/detail/detail.component.ts
+++ b/webapp/frontend/src/app/modules/detail/detail.component.ts
@@ -1,5 +1,15 @@
 import humanizeDuration from 'humanize-duration';
-import {AfterViewInit, Component, Inject, LOCALE_ID, OnDestroy, OnInit, ViewChild} from '@angular/core';
+import {
+    AfterViewInit,
+    ChangeDetectorRef,
+    Component,
+    ElementRef,
+    Inject,
+    LOCALE_ID,
+    OnDestroy,
+    OnInit,
+    ViewChild,
+} from '@angular/core';
 import {ApexOptions} from 'ng-apexcharts';
 import {AppConfig} from 'app/core/config/app.config';
 import {DetailService} from './detail.service';
@@ -17,6 +27,8 @@ import {SmartModel} from 'app/core/models/measurements/smart-model';
 import {SmartAttributeModel} from 'app/core/models/measurements/smart-attribute-model';
 import {AttributeMetadataModel} from 'app/core/models/thresholds/attribute-metadata-model';
 import {DeviceStatusPipe} from 'app/shared/device-status.pipe';
+import {DeviceTitlePipe} from 'app/shared/device-title.pipe';
+import {DetailHtmlExportService} from './detail-html-export.service';
 
 // from Constants.go - these must match
 const AttributeStatusPassed = 0
@@ -52,7 +64,9 @@ export class DetailComponent implements OnInit, AfterViewInit, OnDestroy {
         private _detailService: DetailService,
         public dialog: MatDialog,
         private _configService: ScrutinyConfigService,
-        @Inject(LOCALE_ID) public locale: string
+        @Inject(LOCALE_ID) public locale: string,
+        private readonly changeDetector: ChangeDetectorRef,
+        private readonly htmlExportService: DetailHtmlExportService,
     ) {
         // Set the private defaults
         this._unsubscribeAll = new Subject();
@@ -83,6 +97,9 @@ export class DetailComponent implements OnInit, AfterViewInit, OnDestroy {
 
     @ViewChild('smartAttributeTable', {read: MatSort})
     smartAttributeTableMatSort: MatSort;
+
+    @ViewChild('reportContent', {read: ElementRef})
+    reportContent: ElementRef<HTMLElement>;
 
     // Private
     private _unsubscribeAll: Subject<void>;
@@ -476,6 +493,30 @@ export class DetailComponent implements OnInit, AfterViewInit, OnDestroy {
     toggleOnlyCritical(): void {
         this.onlyCritical = !this.onlyCritical
         this.smartAttributeDataSource.data = this._generateSmartAttributeTableDataSource(this.smart_results);
+    }
+
+    async exportHtmlReport(): Promise<void> {
+        const restoreCriticalOnly = this.onlyCritical;
+        if (restoreCriticalOnly) {
+            this.onlyCritical = false;
+            this.smartAttributeDataSource.data = this._generateSmartAttributeTableDataSource(this.smart_results);
+            this.changeDetector.detectChanges();
+        }
+
+        try {
+            const driveTitle = DeviceTitlePipe.deviceTitleWithFallback(this.device, this.config.dashboard_display);
+            await this.htmlExportService.exportReport(
+                this.reportContent.nativeElement,
+                this.device.model_name,
+                `Drive Details - ${driveTitle}`,
+            );
+        } finally {
+            if (restoreCriticalOnly) {
+                this.onlyCritical = true;
+                this.smartAttributeDataSource.data = this._generateSmartAttributeTableDataSource(this.smart_results);
+                this.changeDetector.detectChanges();
+            }
+        }
     }
 
     openDialog(): void {


### PR DESCRIPTION
## Summary

Implements the HTML report direction discussed in https://github.com/AnalogJ/scrutiny/discussions/1054.

The device-details Export button now downloads a portable, self-contained HTML report containing:

- Drive identity, health, and operating information
- All current S.M.A.R.T. attributes, including rows hidden by the UI filter
- Embedded Scrutiny branding and report-specific CSS
- Printable status chips and table formatting
- A sortable timestamp and drive name in the filename

The report contains no JavaScript, external stylesheets, or external assets, so it can be viewed offline and printed to PDF from a browser.

## Motivation

The existing device-details Export button was not implemented. This provides a shareable drive-health report for uses such as selling or transferring a drive, similar to reports offered by CrystalDiskInfo.

## Testing

- All 90 frontend tests pass
- TypeScript test compilation passes
- Manually exported and opened reports for multiple drive types
- Verified the complete S.M.A.R.T. table is included
- Verified offline viewing and browser print preview

## AI usage disclosure

OpenAI Codex was used extensively to assist with implementation, test creation, debugging, and drafting this pull request. I reviewed the generated changes, iteratively tested the feature in the Scrutiny development environment, and manually verified the exported reports and print output.

No AI-generated media is included; the report embeds Scrutiny’s existing logo asset.