### PR TITLE
fix(frontend): hide the host header when a host has no visible drives

### DIFF
--- a/webapp/frontend/src/app/modules/dashboard/dashboard.component.html
+++ b/webapp/frontend/src/app/modules/dashboard/dashboard.component.html
@@ -62,10 +62,10 @@
 
 
             <div class="flex flex-wrap w-full" *ngFor="let hostId of hostGroups | keyvalue">
-                <h3 class="ml-4" *ngIf="hostId.key">{{ hostId.key }}</h3>
+                <h3 class="ml-4" *ngIf="hostId.key && hostGroupHasVisibleDevices(hostId.value)">{{ hostId.key }}</h3>
                 <div class="flex flex-wrap w-full">
                     <ng-container *ngFor="let deviceSummary of (deviceSummariesForHostGroup(hostId.value) | deviceSort:config.dashboard_sort:config.dashboard_display )">
-                        <app-dashboard-device *ngIf="showArchived || !deviceSummary.device.archived"
+                        <app-dashboard-device *ngIf="isDeviceVisible(deviceSummary)"
                                               (deviceArchived)="onDeviceArchived($event)"
                                               (deviceUnarchived)="onDeviceUnarchived($event)"
                                               (deviceDeleted)="onDeviceDeleted($event)"

--- a/webapp/frontend/src/app/modules/dashboard/dashboard.component.spec.ts
+++ b/webapp/frontend/src/app/modules/dashboard/dashboard.component.spec.ts
@@ -1,0 +1,67 @@
+import {MatDialog} from '@angular/material/dialog';
+import {Router} from '@angular/router';
+import {DashboardComponent} from './dashboard.component';
+import {DashboardService} from './dashboard.service';
+import {ScrutinyConfigService} from 'app/core/config/scrutiny-config.service';
+import {DeviceSummaryModel} from 'app/core/models/device-summary-model';
+
+describe('DashboardComponent', () => {
+    let component: DashboardComponent;
+
+    const deviceSummary = (scrutinyUuid: string, hostId: string, archived: boolean): DeviceSummaryModel => ({
+        device: {
+            scrutiny_uuid: scrutinyUuid,
+            host_id: hostId,
+            archived,
+        },
+    } as DeviceSummaryModel)
+
+    beforeEach(() => {
+        component = new DashboardComponent(
+            jasmine.createSpyObj('DashboardService', ['getSummaryData', 'getSummaryTempData']) as DashboardService,
+            jasmine.createSpyObj('ScrutinyConfigService', ['config']) as ScrutinyConfigService,
+            jasmine.createSpyObj('MatDialog', ['open']) as MatDialog,
+            jasmine.createSpyObj('Router', ['navigate']) as Router,
+        );
+    });
+
+    describe('#hostGroupHasVisibleDevices()', () => {
+
+        it('should be false when every device on the host is archived', () => {
+            component.summaryData = {
+                'uuid-1': deviceSummary('uuid-1', 'my-host', true),
+                'uuid-2': deviceSummary('uuid-2', 'my-host', true),
+            }
+
+            expect(component.hostGroupHasVisibleDevices(['uuid-1', 'uuid-2'])).toBeFalse();
+        });
+
+        it('should be true when at least one device on the host is not archived', () => {
+            component.summaryData = {
+                'uuid-1': deviceSummary('uuid-1', 'my-host', true),
+                'uuid-2': deviceSummary('uuid-2', 'my-host', false),
+            }
+
+            expect(component.hostGroupHasVisibleDevices(['uuid-1', 'uuid-2'])).toBeTrue();
+        });
+
+        it('should be true when every device is archived but archived devices are shown', () => {
+            component.summaryData = {
+                'uuid-1': deviceSummary('uuid-1', 'my-host', true),
+            }
+            component.showArchived = true;
+
+            expect(component.hostGroupHasVisibleDevices(['uuid-1'])).toBeTrue();
+        });
+
+        it('should be false when every device on the host has been deleted', () => {
+            component.summaryData = {
+                'uuid-1': deviceSummary('uuid-1', 'my-host', false),
+            }
+
+            component.onDeviceDeleted('uuid-1')
+
+            expect(component.hostGroupHasVisibleDevices(['uuid-1'])).toBeFalse();
+        });
+    });
+});

--- a/webapp/frontend/src/app/modules/dashboard/dashboard.component.ts
+++ b/webapp/frontend/src/app/modules/dashboard/dashboard.component.ts
@@ -251,6 +251,14 @@ export class DashboardComponent implements OnInit, AfterViewInit, OnDestroy
         return deviceSummaries
     }
 
+    isDeviceVisible(deviceSummary: DeviceSummaryModel): boolean {
+        return this.showArchived || !deviceSummary.device.archived
+    }
+
+    hostGroupHasVisibleDevices(hostGroupScrutinyUUIDs: string[]): boolean {
+        return this.deviceSummariesForHostGroup(hostGroupScrutinyUUIDs).some(deviceSummary => this.isDeviceVisible(deviceSummary))
+    }
+
     openDialog(): void {
         const dialogRef = this.dialog.open(DashboardSettingsComponent, {width: '600px',});
 


### PR DESCRIPTION
Closes #1060.

## The problem

The dashboard groups drives by host and renders a header per group, but the header was only gated on the host id being non-empty:

```html
<h3 class="ml-4" *ngIf="hostId.key">{{ hostId.key }}</h3>
```

Whether a drive renders is decided separately, further down, per drive:

```html
<app-dashboard-device *ngIf="showArchived || !deviceSummary.device.archived" ...>
```

Nothing tied those two conditions together, so a host whose drives were all archived kept its header with nothing underneath it.

The two drifted apart because the header guard came in with host grouping in 83839f7 (2022), and the archive feature in 600cd15 only added the per-drive check without revisiting the header. So rather than adding a second copy of the visibility rule, this puts it in one method and calls it from both places, which is what stops them drifting again.

The same guard also covers a second path to the same symptom: `hostGroups` is built once and `onDeviceDeleted` only removes the drive from `summaryData`, so deleting the last drive on a host used to leave the header behind until a reload.

`hostId.key` is kept, since it still does its original job of suppressing the header for the default empty host id.

## Before

![before](https://raw.githubusercontent.com/justadityaraj/scrutiny/screenshots/issue-1060/issue-1060/before.png)

## After

![after](https://raw.githubusercontent.com/justadityaraj/scrutiny/screenshots/issue-1060/issue-1060/after.png)

## How I tested it

Ran the frontend locally with the dev mocks, flipping the one mock drive on `custom host id` to `archived: true` so that host has no visible drives. Same six drives in both shots, header gone in the second. Verified in the DOM too, `document.querySelectorAll('h3')` goes from `["custom host id"]` to `[]` while `app-dashboard-device` stays at 6.

Also added `dashboard.component.spec.ts` with four cases for the new method: all archived, one not archived, all archived while showing archived, and every drive deleted. Full suite is green, 91 passing, up from 87 on master.

Heads up that this adds `webapp/frontend/src/app/modules/dashboard/dashboard.component.spec.ts`, which #1039 also creates. Whichever lands second needs a trivial rebase, happy to do that if this one goes second.

## AI usage disclosure

Per AI_POLICY.md: written with Claude Code, AI-assisted throughout. I reviewed every line, and the before/after above is a real local run rather than a hypothetical result.
