### PR TITLE
fix(collector): honor a device type set in the config file

### DIFF
--- a/collector/pkg/collector/metrics.go
+++ b/collector/pkg/collector/metrics.go
@@ -137,10 +137,10 @@ func (mc *MetricsCollector) Collect(scrutiny_uuid uuid.UUID, deviceName string, 
 
 	fullDeviceName := fmt.Sprintf("%s%s", detect.DevicePrefix(), deviceName)
 	args := strings.Split(mc.config.GetCommandMetricsSmartArgs(fullDeviceName), " ")
-	//only include the device type if its a non-standard one, or the user pinned it in the config file.
+	//only include the device type if its a non-standard one, or the user set it in the config file.
 	//In some cases ata drives are detected as scsi in docker, and metadata is lost, so a scanned scsi/ata type is dropped.
 	if len(deviceType) > 0 &&
-		((deviceType != "scsi" && deviceType != "ata") || config.HasDeviceTypeOverride(mc.config, fullDeviceName)) {
+		((deviceType != "scsi" && deviceType != "ata") || mc.config.HasDeviceTypeOverride(fullDeviceName)) {
 		args = append(args, "--device", deviceType)
 	}
 	args = append(args, fullDeviceName)

--- a/collector/pkg/collector/metrics.go
+++ b/collector/pkg/collector/metrics.go
@@ -137,8 +137,10 @@ func (mc *MetricsCollector) Collect(scrutiny_uuid uuid.UUID, deviceName string, 
 
 	fullDeviceName := fmt.Sprintf("%s%s", detect.DevicePrefix(), deviceName)
 	args := strings.Split(mc.config.GetCommandMetricsSmartArgs(fullDeviceName), " ")
-	//only include the device type if its a non-standard one. In some cases ata drives are detected as scsi in docker, and metadata is lost.
-	if len(deviceType) > 0 && deviceType != "scsi" && deviceType != "ata" {
+	//only include the device type if its a non-standard one, or the user pinned it in the config file.
+	//In some cases ata drives are detected as scsi in docker, and metadata is lost, so a scanned scsi/ata type is dropped.
+	if len(deviceType) > 0 &&
+		((deviceType != "scsi" && deviceType != "ata") || config.HasDeviceTypeOverride(mc.config, fullDeviceName)) {
 		args = append(args, "--device", deviceType)
 	}
 	args = append(args, fullDeviceName)

--- a/collector/pkg/collector/metrics_test.go
+++ b/collector/pkg/collector/metrics_test.go
@@ -1,9 +1,18 @@
 package collector
 
 import (
-	"github.com/stretchr/testify/require"
+	"errors"
 	"net/url"
 	"testing"
+
+	mock_shell "github.com/analogj/scrutiny/collector/pkg/common/shell/mock"
+	mock_config "github.com/analogj/scrutiny/collector/pkg/config/mock"
+	"github.com/analogj/scrutiny/collector/pkg/detect"
+	"github.com/analogj/scrutiny/collector/pkg/models"
+	"github.com/gofrs/uuid/v5"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 )
 
 func TestApiEndpointParse(t *testing.T) {
@@ -35,4 +44,70 @@ func TestApiEndpointParse_WithBasepathWithTrailingSlash(t *testing.T) {
 
 	url2, _ := baseURL.Parse("/d/e")
 	require.Equal(t, "http://localhost:8080/d/e", url2.String())
+}
+
+func TestMetricsCollector_Collect_DeviceType(t *testing.T) {
+	for _, tt := range []struct {
+		name         string
+		deviceType   string
+		overrides    []models.ScanOverride
+		expectedArgs []string
+	}{
+		{
+			name:         "should drop a scanned scsi type",
+			deviceType:   "scsi",
+			overrides:    []models.ScanOverride{},
+			expectedArgs: []string{"--xall", "--json"},
+		},
+		{
+			name:       "should keep a configured scsi type",
+			deviceType: "scsi",
+			overrides: []models.ScanOverride{
+				{Device: detect.DevicePrefix() + "sda", DeviceType: []string{"scsi"}},
+			},
+			expectedArgs: []string{"--xall", "--json", "--device", "scsi"},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+
+			const (
+				someArgs       = "--xall --json"
+				someDeviceName = "sda"
+			)
+
+			fullDeviceName := detect.DevicePrefix() + someDeviceName
+
+			fakeConfig := mock_config.NewMockInterface(ctrl)
+			fakeConfig.EXPECT().
+				GetCommandMetricsSmartArgs(fullDeviceName).
+				Return(someArgs)
+			fakeConfig.EXPECT().
+				GetString("commands.metrics_smartctl_bin").
+				Return("smartctl")
+			fakeConfig.EXPECT().
+				GetDeviceOverrides().
+				Return(tt.overrides).
+				AnyTimes()
+
+			someLogger := logrus.WithFields(logrus.Fields{})
+
+			fakeShell := mock_shell.NewMockInterface(ctrl)
+			fakeShell.EXPECT().
+				Command(someLogger, "smartctl", append(tt.expectedArgs, fullDeviceName), "", gomock.Any()).
+				Return("", errors.New("smartctl unavailable in test"))
+
+			apiEndpoint, err := url.Parse("http://localhost:8080/")
+			require.NoError(t, err)
+
+			mc := MetricsCollector{
+				config:        fakeConfig,
+				BaseCollector: BaseCollector{logger: someLogger},
+				apiEndpoint:   apiEndpoint,
+				shell:         fakeShell,
+			}
+
+			mc.Collect(uuid.Must(uuid.NewV4()), someDeviceName, tt.deviceType)
+		})
+	}
 }

--- a/collector/pkg/collector/metrics_test.go
+++ b/collector/pkg/collector/metrics_test.go
@@ -8,7 +8,6 @@ import (
 	mock_shell "github.com/analogj/scrutiny/collector/pkg/common/shell/mock"
 	mock_config "github.com/analogj/scrutiny/collector/pkg/config/mock"
 	"github.com/analogj/scrutiny/collector/pkg/detect"
-	"github.com/analogj/scrutiny/collector/pkg/models"
 	"github.com/gofrs/uuid/v5"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
@@ -46,64 +45,40 @@ func TestApiEndpointParse_WithBasepathWithTrailingSlash(t *testing.T) {
 	require.Equal(t, "http://localhost:8080/d/e", url2.String())
 }
 
-func TestMetricsCollector_Collect_DeviceType(t *testing.T) {
+func TestMetricsCollector_Collect_ConfiguredDeviceType(t *testing.T) {
 	for _, tt := range []struct {
-		name         string
-		deviceType   string
-		overrides    []models.ScanOverride
-		expectedArgs []string
+		name                  string
+		deviceType            string
+		hasDeviceTypeOverride bool
+		expectedArgs          []string
 	}{
-		{
-			name:         "should drop a scanned scsi type",
-			deviceType:   "scsi",
-			overrides:    []models.ScanOverride{},
-			expectedArgs: []string{"--xall", "--json"},
-		},
-		{
-			name:       "should keep a configured scsi type",
-			deviceType: "scsi",
-			overrides: []models.ScanOverride{
-				{Device: detect.DevicePrefix() + "sda", DeviceType: []string{"scsi"}},
-			},
-			expectedArgs: []string{"--xall", "--json", "--device", "scsi"},
-		},
+		{"should drop a scanned scsi type", "scsi", false, []string{"--xall", "--json"}},
+		{"should keep a configured scsi type", "scsi", true, []string{"--xall", "--json", "--device", "scsi"}},
+		{"should keep a scanned non-standard type", "megaraid,14", false, []string{"--xall", "--json", "--device", "megaraid,14"}},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 
-			const (
-				someArgs       = "--xall --json"
-				someDeviceName = "sda"
-			)
+			const someDeviceName = "sda"
 
 			fullDeviceName := detect.DevicePrefix() + someDeviceName
 
 			fakeConfig := mock_config.NewMockInterface(ctrl)
-			fakeConfig.EXPECT().
-				GetCommandMetricsSmartArgs(fullDeviceName).
-				Return(someArgs)
-			fakeConfig.EXPECT().
-				GetString("commands.metrics_smartctl_bin").
-				Return("smartctl")
-			fakeConfig.EXPECT().
-				GetDeviceOverrides().
-				Return(tt.overrides).
-				AnyTimes()
+			fakeConfig.EXPECT().GetCommandMetricsSmartArgs(fullDeviceName).Return("--xall --json")
+			fakeConfig.EXPECT().GetString("commands.metrics_smartctl_bin").Return("smartctl")
+			//only consulted for a scsi/ata type; the argv below is what the test pins
+			fakeConfig.EXPECT().HasDeviceTypeOverride(fullDeviceName).AnyTimes().Return(tt.hasDeviceTypeOverride)
 
 			someLogger := logrus.WithFields(logrus.Fields{})
 
 			fakeShell := mock_shell.NewMockInterface(ctrl)
 			fakeShell.EXPECT().
 				Command(someLogger, "smartctl", append(tt.expectedArgs, fullDeviceName), "", gomock.Any()).
-				Return("", errors.New("smartctl unavailable in test"))
-
-			apiEndpoint, err := url.Parse("http://localhost:8080/")
-			require.NoError(t, err)
+				Return("", errors.New("smartctl is not available in tests"))
 
 			mc := MetricsCollector{
 				config:        fakeConfig,
 				BaseCollector: BaseCollector{logger: someLogger},
-				apiEndpoint:   apiEndpoint,
 				shell:         fakeShell,
 			}
 

--- a/collector/pkg/config/config.go
+++ b/collector/pkg/config/config.go
@@ -164,47 +164,38 @@ func (c *configuration) GetDeviceOverrides() []models.ScanOverride {
 	return c.deviceOverrides
 }
 
-// HasDeviceTypeOverride reports whether the user pinned a device type for this
-// device in the config file, as opposed to it coming from `smartctl --scan`.
-func HasDeviceTypeOverride(c Interface, deviceName string) bool {
+func (c *configuration) getDeviceOverride(deviceName string) (models.ScanOverride, bool) {
+	//device files are matched case-insensitively, and the first entry for a device wins.
 	for _, deviceOverride := range c.GetDeviceOverrides() {
 		if strings.EqualFold(deviceName, deviceOverride.Device) {
-			return len(deviceOverride.DeviceType) > 0
+			return deviceOverride, true
 		}
 	}
 
-	return false
+	return models.ScanOverride{}, false
+}
+
+// HasDeviceTypeOverride reports whether the device type was set in the config
+// file, rather than coming from smartctl --scan.
+func (c *configuration) HasDeviceTypeOverride(deviceName string) bool {
+	deviceOverride, found := c.getDeviceOverride(deviceName)
+
+	return found && len(deviceOverride.DeviceType) > 0
 }
 
 func (c *configuration) GetCommandMetricsInfoArgs(deviceName string) string {
-	overrides := c.GetDeviceOverrides()
-
-	for _, deviceOverrides := range overrides {
-		if strings.EqualFold(deviceName, deviceOverrides.Device) {
-			//found matching device
-			if len(deviceOverrides.Commands.MetricsInfoArgs) > 0 {
-				return deviceOverrides.Commands.MetricsInfoArgs
-			} else {
-				return c.GetString("commands.metrics_info_args")
-			}
-		}
+	if deviceOverride, found := c.getDeviceOverride(deviceName); found && len(deviceOverride.Commands.MetricsInfoArgs) > 0 {
+		return deviceOverride.Commands.MetricsInfoArgs
 	}
+
 	return c.GetString("commands.metrics_info_args")
 }
 
 func (c *configuration) GetCommandMetricsSmartArgs(deviceName string) string {
-	overrides := c.GetDeviceOverrides()
-
-	for _, deviceOverrides := range overrides {
-		if strings.EqualFold(deviceName, deviceOverrides.Device) {
-			//found matching device
-			if len(deviceOverrides.Commands.MetricsSmartArgs) > 0 {
-				return deviceOverrides.Commands.MetricsSmartArgs
-			} else {
-				return c.GetString("commands.metrics_smart_args")
-			}
-		}
+	if deviceOverride, found := c.getDeviceOverride(deviceName); found && len(deviceOverride.Commands.MetricsSmartArgs) > 0 {
+		return deviceOverride.Commands.MetricsSmartArgs
 	}
+
 	return c.GetString("commands.metrics_smart_args")
 }
 

--- a/collector/pkg/config/config.go
+++ b/collector/pkg/config/config.go
@@ -164,6 +164,18 @@ func (c *configuration) GetDeviceOverrides() []models.ScanOverride {
 	return c.deviceOverrides
 }
 
+// HasDeviceTypeOverride reports whether the user pinned a device type for this
+// device in the config file, as opposed to it coming from `smartctl --scan`.
+func HasDeviceTypeOverride(c Interface, deviceName string) bool {
+	for _, deviceOverride := range c.GetDeviceOverrides() {
+		if strings.EqualFold(deviceName, deviceOverride.Device) {
+			return len(deviceOverride.DeviceType) > 0
+		}
+	}
+
+	return false
+}
+
 func (c *configuration) GetCommandMetricsInfoArgs(deviceName string) string {
 	overrides := c.GetDeviceOverrides()
 

--- a/collector/pkg/config/config_test.go
+++ b/collector/pkg/config/config_test.go
@@ -141,6 +141,7 @@ func TestConfiguration_OverrideDeviceCommands_MetricsInfoArgs(t *testing.T) {
 
 	//assert
 	require.Equal(t, "--info --json -T permissive", testConfig.GetCommandMetricsInfoArgs("/dev/sda"))
+	require.Equal(t, "--info --json -T permissive", testConfig.GetCommandMetricsInfoArgs("/dev/SDA"))
 	require.Equal(t, "--info --json", testConfig.GetCommandMetricsInfoArgs("/dev/sdb"))
 	//require.Equal(t, []models.ScanOverride{{Device: "/dev/sda", DeviceType: nil, Commands: {MetricsInfoArgs: "--info --json -T "}}}, scanOverrides)
 }
@@ -178,4 +179,33 @@ func TestConfiguration_DeviceAllowList(t *testing.T) {
 		require.True(t, testConfig.IsAllowlistedDevice("/dev/sda"), "/dev/sda should be allow listed")
 		require.True(t, testConfig.IsAllowlistedDevice("/dev/sdc"), "/dev/sda should be allow listed")
 	})
+}
+
+func TestConfiguration_HasDeviceTypeOverride(t *testing.T) {
+	t.Parallel()
+
+	//setup
+	testConfig, _ := config.Create()
+
+	//test
+	err := testConfig.ReadConfig(path.Join("testdata", "simple_device.yaml"))
+	require.NoError(t, err, "should correctly load simple device config")
+
+	//assert
+	require.True(t, testConfig.HasDeviceTypeOverride("/dev/SDA"), "should match a configured device case-insensitively")
+	require.False(t, testConfig.HasDeviceTypeOverride("/dev/sdb"), "should not match an unconfigured device")
+}
+
+func TestConfiguration_HasDeviceTypeOverride_WithoutDeviceType(t *testing.T) {
+	t.Parallel()
+
+	//setup
+	testConfig, _ := config.Create()
+
+	//test
+	err := testConfig.ReadConfig(path.Join("testdata", "ignore_device.yaml"))
+	require.NoError(t, err, "should correctly load ignore device config")
+
+	//assert
+	require.False(t, testConfig.HasDeviceTypeOverride("/dev/sda"), "should not match a device configured without a type")
 }

--- a/collector/pkg/config/interface.go
+++ b/collector/pkg/config/interface.go
@@ -23,6 +23,7 @@ type Interface interface {
 	UnmarshalKey(key string, rawVal interface{}, decoderOpts ...viper.DecoderConfigOption) error
 
 	GetDeviceOverrides() []models.ScanOverride
+	HasDeviceTypeOverride(deviceName string) bool
 	GetCommandMetricsInfoArgs(deviceName string) string
 	GetCommandMetricsSmartArgs(deviceName string) string
 

--- a/collector/pkg/config/mock/mock_config.go
+++ b/collector/pkg/config/mock/mock_config.go
@@ -161,6 +161,20 @@ func (mr *MockInterfaceMockRecorder) GetStringSlice(key interface{}) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStringSlice", reflect.TypeOf((*MockInterface)(nil).GetStringSlice), key)
 }
 
+// HasDeviceTypeOverride mocks base method.
+func (m *MockInterface) HasDeviceTypeOverride(deviceName string) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HasDeviceTypeOverride", deviceName)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// HasDeviceTypeOverride indicates an expected call of HasDeviceTypeOverride.
+func (mr *MockInterfaceMockRecorder) HasDeviceTypeOverride(deviceName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasDeviceTypeOverride", reflect.TypeOf((*MockInterface)(nil).HasDeviceTypeOverride), deviceName)
+}
+
 // Init mocks base method.
 func (m *MockInterface) Init() error {
 	m.ctrl.T.Helper()

--- a/collector/pkg/detect/detect.go
+++ b/collector/pkg/detect/detect.go
@@ -55,8 +55,10 @@ func (d *Detect) SmartctlScan() ([]models.Device, error) {
 func (d *Detect) SmartCtlInfo(device *models.Device) error {
 	fullDeviceName := fmt.Sprintf("%s%s", DevicePrefix(), device.DeviceName)
 	args := strings.Split(d.Config.GetCommandMetricsInfoArgs(fullDeviceName), " ")
-	//only include the device type if its a non-standard one. In some cases ata drives are detected as scsi in docker, and metadata is lost.
-	if len(device.DeviceType) > 0 && device.DeviceType != "scsi" && device.DeviceType != "ata" {
+	//only include the device type if its a non-standard one, or the user pinned it in the config file.
+	//In some cases ata drives are detected as scsi in docker, and metadata is lost, so a scanned scsi/ata type is dropped.
+	if len(device.DeviceType) > 0 &&
+		((device.DeviceType != "scsi" && device.DeviceType != "ata") || config.HasDeviceTypeOverride(d.Config, fullDeviceName)) {
 		args = append(args, "--device", device.DeviceType)
 	}
 	args = append(args, fullDeviceName)

--- a/collector/pkg/detect/detect.go
+++ b/collector/pkg/detect/detect.go
@@ -55,10 +55,10 @@ func (d *Detect) SmartctlScan() ([]models.Device, error) {
 func (d *Detect) SmartCtlInfo(device *models.Device) error {
 	fullDeviceName := fmt.Sprintf("%s%s", DevicePrefix(), device.DeviceName)
 	args := strings.Split(d.Config.GetCommandMetricsInfoArgs(fullDeviceName), " ")
-	//only include the device type if its a non-standard one, or the user pinned it in the config file.
+	//only include the device type if its a non-standard one, or the user set it in the config file.
 	//In some cases ata drives are detected as scsi in docker, and metadata is lost, so a scanned scsi/ata type is dropped.
 	if len(device.DeviceType) > 0 &&
-		((device.DeviceType != "scsi" && device.DeviceType != "ata") || config.HasDeviceTypeOverride(d.Config, fullDeviceName)) {
+		((device.DeviceType != "scsi" && device.DeviceType != "ata") || d.Config.HasDeviceTypeOverride(fullDeviceName)) {
 		args = append(args, "--device", device.DeviceType)
 	}
 	args = append(args, fullDeviceName)

--- a/collector/pkg/detect/detect_test.go
+++ b/collector/pkg/detect/detect_test.go
@@ -545,3 +545,103 @@ func TestDetect_SmartCtlInfo(t *testing.T) {
 		})
 	}
 }
+
+func TestDetect_SmartCtlInfo_DeviceType(t *testing.T) {
+	for _, tt := range []struct {
+		name         string
+		deviceType   string
+		overrides    []models.ScanOverride
+		expectedArgs []string
+	}{
+		{
+			name:         "should pass a scanned non-standard type through",
+			deviceType:   "sat",
+			overrides:    []models.ScanOverride{},
+			expectedArgs: []string{"--info", "--json", "--device", "sat"},
+		},
+		{
+			name:         "should drop a scanned scsi type",
+			deviceType:   "scsi",
+			overrides:    []models.ScanOverride{},
+			expectedArgs: []string{"--info", "--json"},
+		},
+		{
+			name:       "should keep a configured scsi type",
+			deviceType: "scsi",
+			overrides: []models.ScanOverride{
+				{Device: detect.DevicePrefix() + "sda", DeviceType: []string{"scsi"}},
+			},
+			expectedArgs: []string{"--info", "--json", "--device", "scsi"},
+		},
+		{
+			name:       "should keep a configured ata type",
+			deviceType: "ata",
+			overrides: []models.ScanOverride{
+				{Device: detect.DevicePrefix() + "sda", DeviceType: []string{"ata"}},
+			},
+			expectedArgs: []string{"--info", "--json", "--device", "ata"},
+		},
+		{
+			name:       "should drop a scanned scsi type when another device is configured",
+			deviceType: "scsi",
+			overrides: []models.ScanOverride{
+				{Device: detect.DevicePrefix() + "sdb", DeviceType: []string{"scsi"}},
+			},
+			expectedArgs: []string{"--info", "--json"},
+		},
+		{
+			name:       "should drop a scanned scsi type when the override sets no type",
+			deviceType: "scsi",
+			overrides: []models.ScanOverride{
+				{Device: detect.DevicePrefix() + "sda"},
+			},
+			expectedArgs: []string{"--info", "--json"},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+
+			const (
+				someArgs       = "--info --json"
+				someDeviceName = "sda"
+			)
+
+			fullDeviceName := detect.DevicePrefix() + someDeviceName
+
+			fakeConfig := mock_config.NewMockInterface(ctrl)
+			fakeConfig.EXPECT().
+				GetCommandMetricsInfoArgs(fullDeviceName).
+				Return(someArgs)
+			fakeConfig.EXPECT().
+				GetString("commands.metrics_smartctl_bin").
+				Return("smartctl")
+			fakeConfig.EXPECT().
+				GetDeviceOverrides().
+				Return(tt.overrides).
+				AnyTimes()
+
+			someLogger := logrus.WithFields(logrus.Fields{})
+
+			smartctlInfoResults, err := os.ReadFile("testdata/smartctl_info_sata_smart_support_bool.json")
+			require.NoError(t, err)
+
+			fakeShell := mock_shell.NewMockInterface(ctrl)
+			fakeShell.EXPECT().
+				Command(someLogger, "smartctl", append(tt.expectedArgs, fullDeviceName), "", gomock.Any()).
+				Return(string(smartctlInfoResults), nil)
+
+			d := detect.Detect{
+				Logger: someLogger,
+				Shell:  fakeShell,
+				Config: fakeConfig,
+			}
+
+			someDevice := &models.Device{
+				DeviceName: someDeviceName,
+				DeviceType: tt.deviceType,
+			}
+
+			require.NoError(t, d.SmartCtlInfo(someDevice))
+		})
+	}
+}

--- a/collector/pkg/detect/detect_test.go
+++ b/collector/pkg/detect/detect_test.go
@@ -546,79 +546,29 @@ func TestDetect_SmartCtlInfo(t *testing.T) {
 	}
 }
 
-func TestDetect_SmartCtlInfo_DeviceType(t *testing.T) {
+func TestDetect_SmartCtlInfo_ConfiguredDeviceType(t *testing.T) {
 	for _, tt := range []struct {
-		name         string
-		deviceType   string
-		overrides    []models.ScanOverride
-		expectedArgs []string
+		name                  string
+		deviceType            string
+		hasDeviceTypeOverride bool
+		expectedArgs          []string
 	}{
-		{
-			name:         "should pass a scanned non-standard type through",
-			deviceType:   "sat",
-			overrides:    []models.ScanOverride{},
-			expectedArgs: []string{"--info", "--json", "--device", "sat"},
-		},
-		{
-			name:         "should drop a scanned scsi type",
-			deviceType:   "scsi",
-			overrides:    []models.ScanOverride{},
-			expectedArgs: []string{"--info", "--json"},
-		},
-		{
-			name:       "should keep a configured scsi type",
-			deviceType: "scsi",
-			overrides: []models.ScanOverride{
-				{Device: detect.DevicePrefix() + "sda", DeviceType: []string{"scsi"}},
-			},
-			expectedArgs: []string{"--info", "--json", "--device", "scsi"},
-		},
-		{
-			name:       "should keep a configured ata type",
-			deviceType: "ata",
-			overrides: []models.ScanOverride{
-				{Device: detect.DevicePrefix() + "sda", DeviceType: []string{"ata"}},
-			},
-			expectedArgs: []string{"--info", "--json", "--device", "ata"},
-		},
-		{
-			name:       "should drop a scanned scsi type when another device is configured",
-			deviceType: "scsi",
-			overrides: []models.ScanOverride{
-				{Device: detect.DevicePrefix() + "sdb", DeviceType: []string{"scsi"}},
-			},
-			expectedArgs: []string{"--info", "--json"},
-		},
-		{
-			name:       "should drop a scanned scsi type when the override sets no type",
-			deviceType: "scsi",
-			overrides: []models.ScanOverride{
-				{Device: detect.DevicePrefix() + "sda"},
-			},
-			expectedArgs: []string{"--info", "--json"},
-		},
+		{"should drop a scanned scsi type", "scsi", false, []string{"--info", "--json"}},
+		{"should keep a configured scsi type", "scsi", true, []string{"--info", "--json", "--device", "scsi"}},
+		{"should keep a scanned non-standard type", "megaraid,14", false, []string{"--info", "--json", "--device", "megaraid,14"}},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 
-			const (
-				someArgs       = "--info --json"
-				someDeviceName = "sda"
-			)
+			const someDeviceName = "sda"
 
 			fullDeviceName := detect.DevicePrefix() + someDeviceName
 
 			fakeConfig := mock_config.NewMockInterface(ctrl)
-			fakeConfig.EXPECT().
-				GetCommandMetricsInfoArgs(fullDeviceName).
-				Return(someArgs)
-			fakeConfig.EXPECT().
-				GetString("commands.metrics_smartctl_bin").
-				Return("smartctl")
-			fakeConfig.EXPECT().
-				GetDeviceOverrides().
-				Return(tt.overrides).
-				AnyTimes()
+			fakeConfig.EXPECT().GetCommandMetricsInfoArgs(fullDeviceName).Return("--info --json")
+			fakeConfig.EXPECT().GetString("commands.metrics_smartctl_bin").Return("smartctl")
+			//only consulted for a scsi/ata type; the argv below is what the test pins
+			fakeConfig.EXPECT().HasDeviceTypeOverride(fullDeviceName).AnyTimes().Return(tt.hasDeviceTypeOverride)
 
 			someLogger := logrus.WithFields(logrus.Fields{})
 
@@ -636,12 +586,7 @@ func TestDetect_SmartCtlInfo_DeviceType(t *testing.T) {
 				Config: fakeConfig,
 			}
 
-			someDevice := &models.Device{
-				DeviceName: someDeviceName,
-				DeviceType: tt.deviceType,
-			}
-
-			require.NoError(t, d.SmartCtlInfo(someDevice))
+			require.NoError(t, d.SmartCtlInfo(&models.Device{DeviceName: someDeviceName, DeviceType: tt.deviceType}))
 		})
 	}
 }


### PR DESCRIPTION
Fixes #1063.

## What was wrong

The scsi/ata suppression keyed off the device type's **value**, so it could not tell a type that came from `smartctl --scan` from one the user pinned in `collector.yaml`:

```go
if len(device.DeviceType) > 0 && device.DeviceType != "scsi" && device.DeviceType != "ata" {
    args = append(args, "--device", device.DeviceType)
}
```

The suppression itself is correct and stays — the comment explains it, ata drives get scanned as scsi under docker and metadata is lost. The problem is that `TransformDetectedDevices` writes a config override into the *same* `models.Device.DeviceType` field the scanner writes to, so provenance is already gone by the time the guard runs.

So `devices: [{device: /dev/sda, type: scsi}]` produced a bare `smartctl --info --json /dev/sda`, smartctl auto-selected SAT, exited 2, and the drive was dropped with no device info. `ValidateConfig` also rejects `-d` inside `metrics_info_args`, so there is no user-side workaround.

**Both call sites need it.** `detect.go` builds `--info`, `metrics.go` builds `--xall`. Fixing only `detect.go` gets the device registered and then `Collect()` drops the type again — I confirmed that second drop with its own failing test.

## The fix

`HasDeviceTypeOverride` asks the config whether the type was pinned, so suppression now applies only to a scanned type. It is a method on `config.Interface`, sharing one `getDeviceOverride` lookup with `GetCommandMetricsInfoArgs` and `GetCommandMetricsSmartArgs`, and the checked-in gomock is updated to match.

The guard reads `(type != "scsi" && type != "ata") || HasDeviceTypeOverride(...)`, so the config is only consulted for a type that is already scsi/ata. Every other device keeps exactly the old code path, and the existing strict-gomock tests make no unexpected call.

## Verification

**End to end, with the real collector binary** and a stub `smartctl` on `PATH` that logs its argv, against `devices: [{device: /dev/sda, type: scsi}]`:

```
before:  Executing command: smartctl --info --json /dev/sda
after:   Executing command: smartctl --info --json --device scsi /dev/sda
```

The "before" line is byte-for-byte the log in the issue, and the "after" line is exactly the expected behaviour it asks for.

**Tests** — table tests at both call sites. Against the unpatched tree they fail with:

```
detect:   Got: [--info --json /dev/sda]   Want: [--info --json --device scsi /dev/sda]
metrics:  Got: [--xall --json /dev/sda]   Want: [--xall --json --device scsi /dev/sda]
```

They cover the cases that must **not** change too: a scanned `sat` still passes through, a scanned `scsi` is still dropped, an override on a different device doesn't leak, and an override with no `type` set doesn't count. `go test ./collector/...` is green, `go vet` and `gofmt -l` clean.

## Re-verified after the rebase

Against the rebased head, driving the real `config` package and the real `Detect` with a capturing shell and the issue's exact config (`devices: [{device: /dev/sda, type: scsi}]`) and scan result (`/dev/sda`, scanned type `sat`):

```
master 5bf0b25:  smartctl --scan --json
                 smartctl --info --json /dev/sda
this branch:     smartctl --scan --json
                 smartctl --info --json --device scsi /dev/sda
```

The configured `scsi` beats the scanned `sat`, which is the behaviour #803 now preserves through `SmartCtlInfo`.

Behavioural equivalence of the shared lookup was checked the same way: `GetCommandMetricsInfoArgs` and `GetCommandMetricsSmartArgs` return byte-identical results to master across duplicate `device:` entries and mixed-case paths.

`go test ./collector/...` fails the same five pre-existing path tests as master on a Windows host, no more and no fewer; `go vet` and `gofmt -l` are clean.

## AI usage disclosure

Per [AI_POLICY.md](https://github.com/AnalogJ/scrutiny/blob/master/AI_POLICY.md): this was written with **Claude Code**, used substantially — for tracing the two call sites, drafting the patch and the tests, and writing this description.

On the "fully verified with human use" requirement, precisely what I did and did not do: the fix is verified by running the actual `collector-metrics` binary and reading the command it executed, before and after, plus the tests above — not by reasoning about the code. I do **not** have the reporter's USB Seagate BUP drive, so the final `smartctl` exit-status-2 behaviour on that specific hardware is not something I can reproduce; what I verified is the argv scrutiny constructs, which is the part this changes. Happy to adjust if you'd rather see it done differently.

