### PR TITLE
fix(webapp): match observed threshold buckets inclusively on the low end

### DIFF
--- a/webapp/backend/pkg/models/measurements/smart_ata_attribute.go
+++ b/webapp/backend/pkg/models/measurements/smart_ata_attribute.go
@@ -136,9 +136,9 @@ func (sa *SmartAtaAttribute) ValidateThreshold(smartMetadata thresholds.AtaAttri
 
 	for _, obsThresh := range smartMetadata.ObservedThresholds {
 
-		//check if "value" is in this bucket
-		if ((obsThresh.Low == obsThresh.High) && value == obsThresh.Low) ||
-			(obsThresh.Low < value && value <= obsThresh.High) {
+		//check if "value" is in this bucket. Bounds are inclusive on both ends; since the first
+		//matching bucket wins, a value on a shared edge still lands in the earlier bucket.
+		if obsThresh.Low <= value && value <= obsThresh.High {
 			sa.FailureRate = obsThresh.AnnualFailureRate
 
 			if smartMetadata.Critical {

--- a/webapp/backend/pkg/models/measurements/smart_test.go
+++ b/webapp/backend/pkg/models/measurements/smart_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/analogj/scrutiny/webapp/backend/pkg"
 	"github.com/analogj/scrutiny/webapp/backend/pkg/models/collector"
 	"github.com/analogj/scrutiny/webapp/backend/pkg/models/measurements"
+	"github.com/analogj/scrutiny/webapp/backend/pkg/thresholds"
 	"github.com/gofrs/uuid/v5"
 	"github.com/stretchr/testify/require"
 )
@@ -516,4 +517,44 @@ func TestFromCollectorSmartInfo_Scsi(t *testing.T) {
 
 	require.Equal(t, int64(56), smartMdl.Attributes["scsi_grown_defect_list"].(*measurements.SmartScsiAttribute).Value)
 	require.Equal(t, int64(300357663), smartMdl.Attributes["read_errors_corrected_by_eccfast"].(*measurements.SmartScsiAttribute).Value) //total_errors_corrected
+}
+
+func TestSmartAtaAttribute_ValidateThreshold_BucketBoundaries(t *testing.T) {
+	//setup
+	testCases := []struct {
+		name             string
+		attributeId      int
+		value            int64
+		transformedValue int64
+		rawValue         int64
+		expectedStatus   pkg.AttributeStatus
+		expectedRate     float64
+	}{
+		//https://github.com/AnalogJ/scrutiny/issues/1072 - transformed value 0 falls in the [0, 100] bucket
+		{"attr 188 transformed value 0", 188, 100, 0, 0, pkg.AttributeStatusPassed, 0.024893587674442153},
+		{"attr 188 transformed value 100", 188, 100, 100, 0, pkg.AttributeStatusPassed, 0.024893587674442153},
+		{"attr 188 transformed value 101", 188, 100, 101, 0, pkg.AttributeStatusFailedScrutiny, 0.10044174089362015},
+		//raw value 1 falls in the [1, 4] bucket rather than between buckets
+		{"attr 5 raw value 0", 5, 100, 0, 0, pkg.AttributeStatusPassed, 0.025169175350572493},
+		{"attr 5 raw value 1", 5, 100, 0, 1, pkg.AttributeStatusPassed, 0.027432608477803388},
+		{"attr 5 raw value 5", 5, 100, 0, 5, pkg.AttributeStatusPassed, 0.07501976284584981},
+		{"attr 5 raw value 17", 5, 100, 0, 17, pkg.AttributeStatusFailedScrutiny, 0.23589260654405794},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			//test
+			attribute := measurements.SmartAtaAttribute{
+				AttributeId:      testCase.attributeId,
+				Value:            testCase.value,
+				RawValue:         testCase.rawValue,
+				TransformedValue: testCase.transformedValue,
+			}
+			attribute.ValidateThreshold(thresholds.AtaMetadata[testCase.attributeId])
+
+			//assert
+			require.Equal(t, testCase.expectedStatus, attribute.Status)
+			require.Equal(t, testCase.expectedRate, attribute.FailureRate)
+		})
+	}
 }

--- a/webapp/backend/pkg/thresholds/ata_attribute_metadata.go
+++ b/webapp/backend/pkg/thresholds/ata_attribute_metadata.go
@@ -278,7 +278,7 @@ var AtaMetadata = map[int]AtaAttributeMetadata{
 				ErrorInterval:     []float64{0.05113785787727033, 0.05823122757702782},
 			},
 			{ //TODO: using fake data from attribute 11. Not enough data, but critical and correlated with failure.
-				Low:               0,
+				Low:               1,
 				High:              80,
 				AnnualFailureRate: 0.5555555555555556,
 				ErrorInterval:     []float64{0.014065448880161053, 3.095357439410498},
@@ -300,7 +300,7 @@ var AtaMetadata = map[int]AtaAttributeMetadata{
 				ErrorInterval:     []float64{0.03357701137320878, 0.06297433993055492},
 			},
 			{
-				Low:               0,
+				Low:               1,
 				High:              80,
 				AnnualFailureRate: 0.5555555555555556,
 				ErrorInterval:     []float64{0.014065448880161053, 3.095357439410498},
@@ -1103,7 +1103,7 @@ var AtaMetadata = map[int]AtaAttributeMetadata{
 				ErrorInterval:     []float64{0.026159385510707116, 0.03136793218577656},
 			},
 			{
-				Low:               0,
+				Low:               1,
 				High:              2,
 				AnnualFailureRate: 0.8135764944275583,
 				ErrorInterval:     []float64{0.40613445471964466, 1.4557130815309443},


### PR DESCRIPTION
Fixes #1072

## Problem

`ValidateThreshold` matched observed-threshold buckets with a half-open rule:

```go
if ((obsThresh.Low == obsThresh.High) && value == obsThresh.Low) ||
    (obsThresh.Low < value && value <= obsThresh.High) {
```

This leaves a gap at any bucket whose `Low` is not the previous bucket's `High`. Attribute 188's first bucket is `{Low: 0, High: 100}`, so a transformed value of `0` matched nothing, fell through to the no-bucket path, and — because 188 is `Critical` — got `status: 2` / "Could not determine Observed Failure Rate for Critical Attribute". That's the reported symptom: healthy Seagate IronWolf drives with `Command_Timeout = 0` warning.

It isn't specific to 188. The same gap exists wherever a `{0, 0}` bucket is followed by a `{1, N}` bucket — attributes 5, 183, 189, 196 and 197 all fail to match a raw value of exactly `1`. Attribute 5 (`Reallocated Sectors Count`) is `Critical`, so a drive with a single reallocated sector currently warns with the same vague message.

## Fix

Make the bounds inclusive on both ends:

```go
if obsThresh.Low <= value && value <= obsThresh.High {
```

The loop returns on first match, so a value sitting on a shared edge between contiguous buckets still lands in the earlier bucket. Every value that matched before matches the same bucket now — the change only fills the gaps.

## Impact

Replaying old vs. new matching over every SMART fixture in the repo, the only differences are exactly the gap values:

| fixture attr | value | before | after |
|---|---|---|---|
| 188 (critical) | 0 | unmatched → WARN | AFR 2.49%, passes |
| 199 (non-critical) | 0 | unmatched → silent | AFR 4.07%, status unchanged (under 10%) |

No fixture changes status other than the 188 case this is meant to fix.

## Second commit: redundant zero lower bounds

Attributes 10, 11 and 198 declare their second bucket as `{Low: 0, High: N}` sitting behind a `{0, 0}` bucket, so first-match-wins means it only ever sees `1..N`. Written as `{1, N}` the intent is explicit rather than dependent on bucket ordering, and it matches the convention attributes 5, 183, 189, 196 and 197 already use. Verified as a no-op by replaying both forms over the full value range.

## Testing

Added `TestSmartAtaAttribute_ValidateThreshold_BucketBoundaries` covering attribute 188 at 0 / 100 / 101 and attribute 5 at 0 / 1 / 5 / 17 — the latter pinning the shared-edge behaviour and the fail-threshold crossing so the inclusive low bound can't silently shift a value into the wrong bucket.

`go build ./webapp/backend/...` and `go test ./webapp/backend/pkg/models/measurements/...` pass. Note that `go.mod` and `vendor/modules.txt` are out of sync on master already (unrelated to this change); I needed `-mod=mod` to build.

## Not addressed here

Attribute 10 (`Spin Retry Count`, `Critical`) still carries `//TODO: using fake data from attribute 11` on its second bucket — an AFR of 55.6% with an error interval of 0.014–3.10, i.e. essentially one failure in a handful of drive-days. Any non-zero spin retry count fails the drive on that number. Separate issue.

## AI disclosure

Per `AI_POLICY.md`: written with Claude Code (Opus 5). The diff is a few lines of logic, three data constants, and a table-driven test; I reviewed all of it, and the impact table above was produced by replaying the old and new match rules over the repo's fixtures rather than asserted from the model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)